### PR TITLE
Fix command payload validation in protocol handling

### DIFF
--- a/src/server/server.c
+++ b/src/server/server.c
@@ -591,7 +591,7 @@ void server_process_clients(Server* server) {
                     case MSG_COMMAND: {
                         CommandType cmd;
                         uint8_t cmd_data[256];
-                        if (protocol_deserialize_command(payload, &cmd, cmd_data) > 0) {
+                        if (protocol_deserialize_command(payload, header.payload_len, &cmd, cmd_data) > 0) {
                             server_handle_command(server, client, cmd, cmd_data);
                         }
                         break;

--- a/src/shared/protocol.c
+++ b/src/shared/protocol.c
@@ -402,8 +402,8 @@ int protocol_serialize_command(CommandType cmd, const void* data, uint8_t* buffe
     return offset;
 }
 
-int protocol_deserialize_command(const uint8_t* buffer, CommandType* cmd, void* data) {
-    if (!buffer || !cmd) return -1;
+int protocol_deserialize_command(const uint8_t* buffer, size_t len, CommandType* cmd, void* data) {
+    if (!buffer || !cmd || len < 4) return -1;
     
     int offset = 0;
     
@@ -412,14 +412,22 @@ int protocol_deserialize_command(const uint8_t* buffer, CommandType* cmd, void* 
     
     switch (*cmd) {
         case CMD_SELECT_COLONY:
+            if (len < (size_t)(offset + 4)) {
+                return -1;
+            }
             if (data) {
                 CommandSelectColony* sel = (CommandSelectColony*)data;
                 sel->colony_id = read_u32(buffer + offset);
+                offset += 4;
+            } else {
                 offset += 4;
             }
             break;
             
         case CMD_SPAWN_COLONY:
+            if (len < (size_t)(offset + 8 + MAX_COLONY_NAME)) {
+                return -1;
+            }
             if (data) {
                 CommandSpawnColony* spawn = (CommandSpawnColony*)data;
                 spawn->x = read_float(buffer + offset);
@@ -429,6 +437,8 @@ int protocol_deserialize_command(const uint8_t* buffer, CommandType* cmd, void* 
                 memcpy(spawn->name, buffer + offset, MAX_COLONY_NAME);
                 spawn->name[MAX_COLONY_NAME - 1] = '\0';
                 offset += MAX_COLONY_NAME;
+            } else {
+                offset += 8 + MAX_COLONY_NAME;
             }
             break;
             
@@ -439,6 +449,9 @@ int protocol_deserialize_command(const uint8_t* buffer, CommandType* cmd, void* 
         case CMD_RESET:
             // No additional data
             break;
+
+        default:
+            return -1;
     }
     
     return offset;

--- a/src/shared/protocol.h
+++ b/src/shared/protocol.h
@@ -118,7 +118,7 @@ int protocol_serialize_colony(const proto_colony* colony, uint8_t* buffer);
 int protocol_deserialize_colony(const uint8_t* buffer, proto_colony* colony);
 
 int protocol_serialize_command(CommandType cmd, const void* data, uint8_t* buffer);
-int protocol_deserialize_command(const uint8_t* buffer, CommandType* cmd, void* data);
+int protocol_deserialize_command(const uint8_t* buffer, size_t len, CommandType* cmd, void* data);
 
 // Grid serialization with RLE compression
 int protocol_serialize_grid_rle(const uint16_t* grid, uint32_t size, uint8_t** buffer, size_t* len);

--- a/tests/test_phase4.c
+++ b/tests/test_phase4.c
@@ -188,7 +188,7 @@ int test_protocol_command_serialization_roundtrip(void) {
     TEST_ASSERT(size > 0, "Serialize pause command should succeed");
     
     CommandType cmd;
-    int result = protocol_deserialize_command(buffer, &cmd, NULL);
+    int result = protocol_deserialize_command(buffer, (size_t)size, &cmd, NULL);
     TEST_ASSERT(result > 0, "Deserialize pause command should succeed");
     TEST_ASSERT_EQ(cmd, CMD_PAUSE, "Command type should be PAUSE");
     
@@ -198,7 +198,7 @@ int test_protocol_command_serialization_roundtrip(void) {
     TEST_ASSERT(size > 0, "Serialize select command should succeed");
     
     CommandSelectColony decoded_select;
-    result = protocol_deserialize_command(buffer, &cmd, &decoded_select);
+    result = protocol_deserialize_command(buffer, (size_t)size, &cmd, &decoded_select);
     TEST_ASSERT(result > 0, "Deserialize select command should succeed");
     TEST_ASSERT_EQ(cmd, CMD_SELECT_COLONY, "Command type should be SELECT_COLONY");
     TEST_ASSERT_EQ(decoded_select.colony_id, 42, "Colony ID should match");
@@ -210,7 +210,7 @@ int test_protocol_command_serialization_roundtrip(void) {
     TEST_ASSERT(size > 0, "Serialize spawn command should succeed");
     
     CommandSpawnColony decoded_spawn;
-    result = protocol_deserialize_command(buffer, &cmd, &decoded_spawn);
+    result = protocol_deserialize_command(buffer, (size_t)size, &cmd, &decoded_spawn);
     TEST_ASSERT(result > 0, "Deserialize spawn command should succeed");
     TEST_ASSERT_EQ(cmd, CMD_SPAWN_COLONY, "Command type should be SPAWN_COLONY");
     TEST_ASSERT_FLOAT_EQ(decoded_spawn.x, 123.5f, "Spawn X should match");
@@ -466,7 +466,7 @@ int test_protocol_and_network_handle_null_safely(void) {
     TEST_ASSERT(protocol_serialize_colony(NULL, NULL) < 0, "Should fail with NULL");
     TEST_ASSERT(protocol_deserialize_colony(NULL, NULL) < 0, "Should fail with NULL");
     TEST_ASSERT(protocol_serialize_command(CMD_PAUSE, NULL, NULL) < 0, "Should fail with NULL buffer");
-    TEST_ASSERT(protocol_deserialize_command(NULL, NULL, NULL) < 0, "Should fail with NULL");
+    TEST_ASSERT(protocol_deserialize_command(NULL, 0, NULL, NULL) < 0, "Should fail with NULL");
     TEST_ASSERT(protocol_serialize_world_state(NULL, NULL, NULL) < 0, "Should fail with NULL");
     TEST_ASSERT(protocol_deserialize_world_state(NULL, 0, NULL) < 0, "Should fail with NULL");
     

--- a/tests/test_protocol_edge.c
+++ b/tests/test_protocol_edge.c
@@ -353,7 +353,7 @@ TEST(all_command_types) {
         ASSERT(size > 0, "Command serialization should succeed");
         
         CommandType deserialized;
-        size = protocol_deserialize_command(buffer, &deserialized, NULL);
+        size = protocol_deserialize_command(buffer, (size_t)size, &deserialized, NULL);
         ASSERT(size > 0, "Command deserialization should succeed");
         ASSERT_EQ(deserialized, commands[i]);
     }
@@ -368,7 +368,7 @@ TEST(select_colony_command) {
     
     CommandType cmd;
     CommandSelectColony deserialized;
-    size = protocol_deserialize_command(buffer, &cmd, &deserialized);
+    size = protocol_deserialize_command(buffer, (size_t)size, &cmd, &deserialized);
     ASSERT(size > 0, "Deserialization should succeed");
     ASSERT_EQ(cmd, CMD_SELECT_COLONY);
     ASSERT_EQ(deserialized.colony_id, 12345);
@@ -388,13 +388,29 @@ TEST(spawn_colony_command) {
     
     CommandType cmd;
     CommandSpawnColony deserialized;
-    size = protocol_deserialize_command(buffer, &cmd, &deserialized);
+    size = protocol_deserialize_command(buffer, (size_t)size, &cmd, &deserialized);
     ASSERT(size > 0, "Deserialization should succeed");
     ASSERT_EQ(cmd, CMD_SPAWN_COLONY);
     
     // Float comparison with tolerance
     ASSERT(fabsf(deserialized.x - 123.456f) < 0.001f, "X should match");
     ASSERT(fabsf(deserialized.y - 789.012f) < 0.001f, "Y should match");
+}
+
+TEST(rejects_truncated_command_payload) {
+    uint8_t buffer[128];
+    CommandType cmd;
+
+    CommandSelectColony select_data = { .colony_id = 123 };
+    int select_size = protocol_serialize_command(CMD_SELECT_COLONY, &select_data, buffer);
+    ASSERT(select_size > 0, "Serialization should succeed");
+    ASSERT_EQ(protocol_deserialize_command(buffer, 4, &cmd, NULL), -1);
+
+    CommandSpawnColony spawn_data = { .x = 1.0f, .y = 2.0f };
+    strncpy(spawn_data.name, "tiny", MAX_COLONY_NAME);
+    int spawn_size = protocol_serialize_command(CMD_SPAWN_COLONY, &spawn_data, buffer);
+    ASSERT(spawn_size > 0, "Serialization should succeed");
+    ASSERT_EQ(protocol_deserialize_command(buffer, 8, &cmd, NULL), -1);
 }
 
 // ============================================================================
@@ -512,6 +528,7 @@ int run_protocol_edge_tests(void) {
     RUN_TEST(all_command_types);
     RUN_TEST(select_colony_command);
     RUN_TEST(spawn_colony_command);
+    RUN_TEST(rejects_truncated_command_payload);
     
     printf("\nNull Input Tests:\n");
     RUN_TEST(null_inputs_handled);


### PR DESCRIPTION
## Summary
- make `protocol_deserialize_command` length-aware and reject truncated/unknown command payloads
- pass network payload length from server message processing before command decode
- update protocol tests and add truncated-payload regression coverage

Closes #3