### PR TITLE
Fix reset UAF and harden server shutdown lifecycle

### DIFF
--- a/src/server/main.c
+++ b/src/server/main.c
@@ -14,16 +14,18 @@
 #include "world.h"
 #include "atomic_sim.h"
 
-// Global server pointer for signal handler
-static Server* g_server = NULL;
+static volatile sig_atomic_t g_shutdown_requested = 0;
 
 // Signal handler for graceful shutdown
 static void signal_handler(int sig) {
     (void)sig;
-    printf("\nReceived shutdown signal, stopping server...\n");
-    if (g_server) {
-        server_stop(g_server);
-    }
+    g_shutdown_requested = 1;
+}
+
+static void* server_thread_main(void* arg) {
+    Server* server = (Server*)arg;
+    server_run(server);
+    return NULL;
 }
 
 // Print usage information
@@ -142,9 +144,6 @@ int main(int argc, char* argv[]) {
         atomic_world_sync_from_world(server->atomic_world);
     }
     
-    // Set global server for signal handler
-    g_server = server;
-    
     // Setup signal handlers
     struct sigaction sa;
     memset(&sa, 0, sizeof(sa));
@@ -158,13 +157,25 @@ int main(int argc, char* argv[]) {
     printf("Server listening on port %u\n", server_get_port(server));
     printf("Press Ctrl+C to stop\n\n");
     
-    // Run server (blocking)
-    server_run(server);
+    // Run server in a dedicated thread and handle shutdown in main thread
+    pthread_t server_thread;
+    if (pthread_create(&server_thread, NULL, server_thread_main, server) != 0) {
+        fprintf(stderr, "Error: Failed to start server thread\n");
+        server_destroy(server);
+        return 1;
+    }
+
+    while (!g_shutdown_requested) {
+        pause();
+    }
+
+    printf("\nReceived shutdown signal, stopping server...\n");
+    server_stop(server);
+    pthread_join(server_thread, NULL);
     
     // Cleanup
     printf("Shutting down...\n");
     server_destroy(server);
-    g_server = NULL;
     
     printf("Server stopped.\n");
     return 0;

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -22,6 +22,7 @@
 // Forward declarations for thread functions
 static void* accept_thread_func(void* arg);
 static void* simulation_thread_func(void* arg);
+static bool server_rebuild_world_state(Server* server, int width, int height, int initial_colonies);
 
 // Helper to get current time in milliseconds
 static long get_time_ms(void) {
@@ -270,9 +271,59 @@ void server_stop(Server* server) {
     
     // Close listener to unblock accept
     if (server->listener) {
-        net_server_destroy(server->listener);
-        server->listener = NULL;
+        net_server_stop(server->listener);
     }
+}
+
+static bool server_rebuild_world_state(Server* server, int width, int height, int initial_colonies) {
+    if (!server || width <= 0 || height <= 0) {
+        return false;
+    }
+
+    World* new_world = world_create(width, height);
+    if (!new_world) {
+        return false;
+    }
+
+    if (initial_colonies > 0) {
+        world_init_random_colonies(new_world, initial_colonies);
+    }
+
+    int regions = server->pool && server->pool->thread_count > 1 ? 4 : 2;
+    ParallelContext* new_parallel = parallel_create(server->pool, new_world, regions, regions);
+    if (!new_parallel) {
+        world_destroy(new_world);
+        return false;
+    }
+    parallel_init_regions(new_parallel, width, height);
+
+    int thread_count = server->pool ? server->pool->thread_count : 1;
+    AtomicWorld* new_atomic = atomic_world_create(new_world, server->pool, thread_count);
+    if (!new_atomic) {
+        parallel_destroy(new_parallel);
+        world_destroy(new_world);
+        return false;
+    }
+
+    AtomicWorld* old_atomic = server->atomic_world;
+    ParallelContext* old_parallel = server->parallel_ctx;
+    World* old_world = server->world;
+
+    server->world = new_world;
+    server->parallel_ctx = new_parallel;
+    server->atomic_world = new_atomic;
+
+    if (old_atomic) {
+        atomic_world_destroy(old_atomic);
+    }
+    if (old_parallel) {
+        parallel_destroy(old_parallel);
+    }
+    if (old_world) {
+        world_destroy(old_world);
+    }
+
+    return true;
 }
 
 // Convert internal World/Colony to protocol proto_world for serialization
@@ -477,12 +528,14 @@ void server_handle_command(Server* server, client_session* client, CommandType c
             break;
             
         case CMD_RESET:
-            // Reset world
-            world_destroy(server->world);
-            server->world = world_create(server->parallel_ctx->regions[0].end_x * server->parallel_ctx->regions_x,
-                                          server->parallel_ctx->regions[0].end_y * server->parallel_ctx->regions_y);
+            // Reset world while preserving dimensions
             if (server->world) {
-                world_init_random_colonies(server->world, 5);
+                int width = server->world->width;
+                int height = server->world->height;
+                if (!server_rebuild_world_state(server, width, height, 5)) {
+                    fprintf(stderr, "Failed to reset world for client %u\n", client->id);
+                    break;
+                }
             }
             printf("World reset by client %u\n", client->id);
             break;

--- a/src/shared/network.c
+++ b/src/shared/network.c
@@ -58,13 +58,21 @@ net_server* net_server_create(uint16_t port) {
     return server;
 }
 
-void net_server_destroy(net_server* server) {
+void net_server_stop(net_server* server) {
     if (!server) return;
-    
+
     if (server->fd >= 0) {
+        shutdown(server->fd, SHUT_RDWR);
         close(server->fd);
+        server->fd = -1;
     }
     server->listening = false;
+}
+
+void net_server_destroy(net_server* server) {
+    if (!server) return;
+
+    net_server_stop(server);
     free(server);
 }
 

--- a/src/shared/network.h
+++ b/src/shared/network.h
@@ -22,6 +22,7 @@ typedef struct net_server {
 
 // Server functions
 net_server* net_server_create(uint16_t port);
+void net_server_stop(net_server* server);
 void net_server_destroy(net_server* server);
 net_socket* net_server_accept(net_server* server);  // Blocking accept
 


### PR DESCRIPTION
## Summary
- rebuild world, parallel context, and atomic world together on reset to avoid stale pointers
- add listener stop primitive and use it to coordinate accept-loop shutdown without freeing shared state early
- make signal handler async-signal-safe by switching to a shutdown flag and moving stop/logging to main thread

Closes #2
Closes #7
Closes #8