### PR TITLE
ci: handle gcov negative-hit parse errors in coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,8 +215,8 @@ jobs:
       - name: Generate coverage summary
         run: |
           export PATH="$HOME/.local/bin:$PATH"
-          uvx gcovr --root . --gcov-ignore-parse-errors=suspicious_hits.warn_once_per_file --print-summary --txt > coverage-summary.txt
-          uvx gcovr --root . --gcov-ignore-parse-errors=suspicious_hits.warn_once_per_file --xml-pretty --output coverage.xml
+          uvx gcovr --root . --gcov-ignore-parse-errors=suspicious_hits.warn_once_per_file --gcov-ignore-parse-errors=negative_hits.warn_once_per_file --print-summary --txt > coverage-summary.txt
+          uvx gcovr --root . --gcov-ignore-parse-errors=suspicious_hits.warn_once_per_file --gcov-ignore-parse-errors=negative_hits.warn_once_per_file --xml-pretty --output coverage.xml
           cat coverage-summary.txt
 
       - name: Add coverage to job summary
@@ -266,8 +266,8 @@ jobs:
       - name: Generate coverage summary
         run: |
           export PATH="$HOME/.local/bin:$PATH"
-          uvx gcovr --root . --gcov-ignore-parse-errors=suspicious_hits.warn_once_per_file --print-summary --txt > coverage-summary.txt
-          uvx gcovr --root . --gcov-ignore-parse-errors=suspicious_hits.warn_once_per_file --xml-pretty --output coverage.xml
+          uvx gcovr --root . --gcov-ignore-parse-errors=suspicious_hits.warn_once_per_file --gcov-ignore-parse-errors=negative_hits.warn_once_per_file --print-summary --txt > coverage-summary.txt
+          uvx gcovr --root . --gcov-ignore-parse-errors=suspicious_hits.warn_once_per_file --gcov-ignore-parse-errors=negative_hits.warn_once_per_file --xml-pretty --output coverage.xml
           cat coverage-summary.txt
 
       - name: Add coverage to job summary


### PR DESCRIPTION
## Summary
- Extend coverage gcovr parse-error handling to include negative_hits.warn_once_per_file in addition to suspicious hits.
- Apply the same setting to both coverage-macos and coverage-ferox jobs.

## Why
- Main CI run 22296901169 failed in coverage-ferox due to gcov negative-hit parse errors from known gcov bugs.
- This keeps coverage reporting running while still surfacing warnings.

## Validation
- Verified failing log indicates a NegativeHits parse exception in coverage-ferox.
- Updated workflow options to tolerate that parse class in both coverage jobs.