### PR TITLE
test: add targeted branch coverage for server/world paths

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -123,6 +123,17 @@ target_link_libraries(test_gui PRIVATE m)
 target_compile_definitions(test_gui PRIVATE STANDALONE_TEST)
 add_test(NAME GuiTests COMMAND test_gui)
 
+# Targeted branch coverage tests for world/server paths
+add_executable(test_world_branch_coverage test_world_branch_coverage.c)
+target_link_libraries(test_world_branch_coverage PRIVATE ferox_server_lib)
+target_compile_definitions(test_world_branch_coverage PRIVATE STANDALONE_TEST)
+add_test(NAME WorldBranchCoverageTests COMMAND test_world_branch_coverage)
+
+add_executable(test_server_branch_coverage test_server_branch_coverage.c)
+target_link_libraries(test_server_branch_coverage PRIVATE ferox_server_lib)
+target_compile_definitions(test_server_branch_coverage PRIVATE STANDALONE_TEST)
+add_test(NAME ServerBranchCoverageTests COMMAND test_server_branch_coverage)
+
 # Combined test runner
 add_executable(test_runner test_runner.c
     test_genetics_advanced.c

--- a/tests/test_server_branch_coverage.c
+++ b/tests/test_server_branch_coverage.c
@@ -1,0 +1,188 @@
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../src/server/server.h"
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+static int current_test_failed = 0;
+
+#define TEST(name) static void test_##name(void)
+#define RUN_TEST(name) do { \
+    printf("Running %s... ", #name); \
+    fflush(stdout); \
+    current_test_failed = 0; \
+    test_##name(); \
+    if (!current_test_failed) { \
+        printf("OK\n"); \
+        tests_passed++; \
+    } \
+} while (0)
+
+#define ASSERT(cond, msg) do { \
+    if (!(cond)) { \
+        printf("FAIL\n  %s (%s:%d)\n", msg, __FILE__, __LINE__); \
+        current_test_failed = 1; \
+        tests_failed++; \
+        return; \
+    } \
+} while (0)
+
+#define ASSERT_TRUE(cond) ASSERT((cond), #cond)
+#define ASSERT_EQ(a, b) ASSERT((a) == (b), #a " == " #b)
+#define ASSERT_NE(a, b) ASSERT((a) != (b), #a " != " #b)
+
+static net_socket* make_mock_socket(bool connected) {
+    net_socket* socket = (net_socket*)calloc(1, sizeof(net_socket));
+    if (!socket) {
+        return NULL;
+    }
+    socket->fd = -1;
+    socket->connected = connected;
+    return socket;
+}
+
+TEST(server_handle_command_clamps_speed_limits) {
+    Server* server = server_create(0, 20, 20, 2);
+    ASSERT_TRUE(server != NULL);
+
+    net_socket* socket = make_mock_socket(true);
+    ASSERT_TRUE(socket != NULL);
+    client_session* client = server_add_client(server, socket);
+    ASSERT_TRUE(client != NULL);
+
+    server->speed_multiplier = 99.0f;
+    server_handle_command(server, client, CMD_SPEED_UP, NULL);
+    ASSERT_TRUE(server->speed_multiplier == 100.0f);
+
+    server_handle_command(server, client, CMD_SPEED_UP, NULL);
+    ASSERT_TRUE(server->speed_multiplier == 100.0f);
+
+    server->speed_multiplier = 0.11f;
+    server_handle_command(server, client, CMD_SLOW_DOWN, NULL);
+    ASSERT_TRUE(server->speed_multiplier == 0.1f);
+
+    server_handle_command(server, client, CMD_SLOW_DOWN, NULL);
+    ASSERT_TRUE(server->speed_multiplier == 0.1f);
+
+    server_destroy(server);
+}
+
+TEST(server_handle_command_reset_rebuilds_world) {
+    Server* server = server_create(0, 21, 13, 2);
+    ASSERT_TRUE(server != NULL);
+
+    net_socket* socket = make_mock_socket(true);
+    ASSERT_TRUE(socket != NULL);
+    client_session* client = server_add_client(server, socket);
+    ASSERT_TRUE(client != NULL);
+
+    World* old_world = server->world;
+    AtomicWorld* old_atomic = server->atomic_world;
+    ParallelContext* old_parallel = server->parallel_ctx;
+
+    server_handle_command(server, client, CMD_RESET, NULL);
+
+    ASSERT_TRUE(server->world != NULL);
+    ASSERT_TRUE(server->atomic_world != NULL);
+    ASSERT_TRUE(server->parallel_ctx != NULL);
+    ASSERT_NE(server->world, old_world);
+    ASSERT_NE(server->atomic_world, old_atomic);
+    ASSERT_NE(server->parallel_ctx, old_parallel);
+    ASSERT_EQ(server->world->width, 21);
+    ASSERT_EQ(server->world->height, 13);
+
+    server_destroy(server);
+}
+
+TEST(server_handle_command_data_branches_for_select_and_spawn) {
+    Server stub = {0};
+    client_session client = {0};
+    client.id = 77;
+
+    server_handle_command(&stub, &client, CMD_SELECT_COLONY, NULL);
+    ASSERT_EQ(client.selected_colony, 0u);
+
+    CommandSelectColony select_colony = {.colony_id = 42};
+    server_handle_command(&stub, &client, CMD_SELECT_COLONY, &select_colony);
+    ASSERT_EQ(client.selected_colony, 42u);
+
+    server_handle_command(&stub, &client, CMD_SPAWN_COLONY, NULL);
+
+    CommandSpawnColony spawn = {.x = 2.0f, .y = 4.0f};
+    server_handle_command(&stub, &client, CMD_SPAWN_COLONY, &spawn);
+}
+
+TEST(server_remove_client_noop_when_target_missing) {
+    Server* server = server_create(0, 20, 20, 2);
+    ASSERT_TRUE(server != NULL);
+
+    net_socket* socket = make_mock_socket(true);
+    ASSERT_TRUE(socket != NULL);
+    client_session* tracked = server_add_client(server, socket);
+    ASSERT_TRUE(tracked != NULL);
+    ASSERT_EQ(server->client_count, 1);
+
+    client_session ghost = {0};
+    server_remove_client(server, &ghost);
+    ASSERT_EQ(server->client_count, 1);
+
+    server_destroy(server);
+}
+
+TEST(server_process_clients_skips_non_connected_clients) {
+    Server* server = server_create(0, 20, 20, 2);
+    ASSERT_TRUE(server != NULL);
+
+    net_socket* inactive_socket = make_mock_socket(true);
+    net_socket* disconnected_socket = make_mock_socket(false);
+    ASSERT_TRUE(inactive_socket != NULL);
+    ASSERT_TRUE(disconnected_socket != NULL);
+
+    client_session* inactive_client = server_add_client(server, inactive_socket);
+    client_session* disconnected_client = server_add_client(server, disconnected_socket);
+    ASSERT_TRUE(inactive_client != NULL);
+    ASSERT_TRUE(disconnected_client != NULL);
+
+    inactive_client->active = false;
+    disconnected_client->active = true;
+
+    server_process_clients(server);
+    ASSERT_EQ(server->client_count, 2);
+
+    server_destroy(server);
+}
+
+TEST(server_stop_and_get_port_guard_branches) {
+    Server* server = server_create(0, 20, 20, 2);
+    ASSERT_TRUE(server != NULL);
+
+    atomic_store(&server->running, false);
+    server_stop(server);
+    ASSERT_TRUE(!atomic_load(&server->running));
+
+    atomic_store(&server->running, true);
+    server_stop(server);
+    ASSERT_TRUE(!atomic_load(&server->running));
+
+    Server stub = {0};
+    ASSERT_EQ(server_get_port(&stub), 0u);
+
+    server_destroy(server);
+}
+
+int main(void) {
+    printf("=== Server Branch Coverage Tests ===\n");
+
+    RUN_TEST(server_handle_command_clamps_speed_limits);
+    RUN_TEST(server_handle_command_reset_rebuilds_world);
+    RUN_TEST(server_handle_command_data_branches_for_select_and_spawn);
+    RUN_TEST(server_remove_client_noop_when_target_missing);
+    RUN_TEST(server_process_clients_skips_non_connected_clients);
+    RUN_TEST(server_stop_and_get_port_guard_branches);
+
+    printf("Passed: %d\n", tests_passed);
+    printf("Failed: %d\n", tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/tests/test_world_branch_coverage.c
+++ b/tests/test_world_branch_coverage.c
@@ -1,0 +1,200 @@
+#include <limits.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../src/server/world.h"
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+static int current_test_failed = 0;
+
+#define TEST(name) static void test_##name(void)
+#define RUN_TEST(name) do { \
+    printf("Running %s... ", #name); \
+    fflush(stdout); \
+    current_test_failed = 0; \
+    test_##name(); \
+    if (!current_test_failed) { \
+        printf("OK\n"); \
+        tests_passed++; \
+    } \
+} while(0)
+
+#define ASSERT(cond, msg) do { \
+    if (!(cond)) { \
+        printf("FAIL\n  %s (%s:%d)\n", msg, __FILE__, __LINE__); \
+        current_test_failed = 1; \
+        tests_failed++; \
+        return; \
+    } \
+} while (0)
+
+#define ASSERT_TRUE(cond) ASSERT((cond), #cond)
+#define ASSERT_EQ(a, b) ASSERT((a) == (b), #a " == " #b)
+#define ASSERT_NULL(ptr) ASSERT((ptr) == NULL, #ptr " is NULL")
+#define ASSERT_NOT_NULL(ptr) ASSERT((ptr) != NULL, #ptr " is not NULL")
+
+static Colony make_colony(void) {
+    Colony colony;
+    memset(&colony, 0, sizeof(colony));
+    strncpy(colony.name, "Test colony", sizeof(colony.name) - 1);
+    colony.active = true;
+    return colony;
+}
+
+TEST(world_create_rejects_invalid_sizes) {
+    ASSERT_NULL(world_create(0, 4));
+    ASSERT_NULL(world_create(4, 0));
+    ASSERT_NULL(world_create(-1, 4));
+    ASSERT_NULL(world_create(4, -1));
+
+    ASSERT_NULL(world_create(INT_MAX, 2));
+
+    World* world = world_create(1, 1);
+    ASSERT_NOT_NULL(world);
+    world_destroy(world);
+}
+
+TEST(world_get_colony_checks_lookup_and_active_state) {
+    World* world = world_create(4, 4);
+    ASSERT_NOT_NULL(world);
+
+    Colony colony = make_colony();
+    uint32_t id = world_add_colony(world, colony);
+    ASSERT_TRUE(id != 0);
+    ASSERT_NOT_NULL(world_get_colony(world, id));
+
+    world->colonies[0].active = false;
+    ASSERT_NULL(world_get_colony(world, id));
+
+    world->colonies[0].active = true;
+    world->colony_by_id[id] = NULL;
+    ASSERT_NULL(world_get_colony(world, id));
+
+    ASSERT_NULL(world_get_colony(world, 0));
+    ASSERT_NULL(world_get_colony(world, (uint32_t)world->colony_by_id_capacity + 10));
+
+    world_destroy(world);
+}
+
+TEST(world_add_colony_rejects_uint32_id_overflow) {
+    World* world = world_create(4, 4);
+    ASSERT_NOT_NULL(world);
+
+    atomic_store(&world->next_colony_id, UINT32_MAX);
+    uint32_t id = world_add_colony(world, make_colony());
+    ASSERT_EQ(id, 0u);
+    ASSERT_EQ(world->colony_count, 0u);
+
+    world_destroy(world);
+}
+
+TEST(world_colony_cell_tracking_updates_centroid_both_paths) {
+    World* world = world_create(10, 10);
+    ASSERT_NOT_NULL(world);
+
+    uint32_t id = world_add_colony(world, make_colony());
+    ASSERT_TRUE(id != 0);
+    Colony* colony = world_get_colony(world, id);
+    ASSERT_NOT_NULL(colony);
+
+    uint32_t first = 3u * 10u + 2u;
+    colony->cell_count = 1;
+    world_colony_add_cell(world, id, first);
+    ASSERT_EQ(colony->cell_indices_count, 1u);
+    ASSERT_TRUE(colony->cell_indices_capacity >= 64u);
+    ASSERT_TRUE(colony->centroid_x > 1.99f && colony->centroid_x < 2.01f);
+    ASSERT_TRUE(colony->centroid_y > 2.99f && colony->centroid_y < 3.01f);
+
+    uint32_t second = 3u * 10u + 3u;
+    colony->cell_count = 2;
+    world_colony_add_cell(world, id, second);
+    ASSERT_EQ(colony->cell_indices_count, 2u);
+    ASSERT_TRUE(colony->centroid_x > 2.49f && colony->centroid_x < 2.51f);
+    ASSERT_TRUE(colony->centroid_y > 2.99f && colony->centroid_y < 3.01f);
+
+    colony->cell_count = 2;
+    world_colony_remove_cell(world, id, second);
+    ASSERT_EQ(colony->cell_indices_count, 1u);
+    ASSERT_TRUE(colony->centroid_x > 1.99f && colony->centroid_x < 2.01f);
+    ASSERT_TRUE(colony->centroid_y > 2.99f && colony->centroid_y < 3.01f);
+
+    colony->cell_count = 1;
+    world_colony_remove_cell(world, id, first);
+    ASSERT_EQ(colony->cell_indices_count, 0u);
+    ASSERT_TRUE(colony->centroid_x == 0.0f);
+    ASSERT_TRUE(colony->centroid_y == 0.0f);
+
+    world_colony_add_cell(world, 0, 0);
+    world_colony_remove_cell(world, 0, 0);
+
+    world_destroy(world);
+}
+
+TEST(world_remove_colony_uses_tracked_and_fallback_clear_paths) {
+    World* world = world_create(8, 8);
+    ASSERT_NOT_NULL(world);
+
+    uint32_t tracked_id = world_add_colony(world, make_colony());
+    uint32_t scan_id = world_add_colony(world, make_colony());
+    ASSERT_TRUE(tracked_id != 0 && scan_id != 0);
+
+    Colony* tracked = world_get_colony(world, tracked_id);
+    ASSERT_NOT_NULL(tracked);
+
+    uint32_t tracked_a = 1u * 8u + 1u;
+    uint32_t tracked_b = 1u * 8u + 2u;
+    world->cells[tracked_a].colony_id = tracked_id;
+    world->cells[tracked_b].colony_id = tracked_id;
+    world->cells[tracked_a].age = 9;
+    world->cells[tracked_b].age = 7;
+
+    tracked->cell_count = 1;
+    world_colony_add_cell(world, tracked_id, tracked_a);
+    tracked->cell_count = 2;
+    world_colony_add_cell(world, tracked_id, tracked_b);
+
+    uint32_t scan_a = 6u * 8u + 6u;
+    uint32_t scan_b = 6u * 8u + 7u;
+    world->cells[scan_a].colony_id = scan_id;
+    world->cells[scan_b].colony_id = scan_id;
+    world->cells[scan_a].age = 3;
+    world->cells[scan_b].age = 4;
+
+    world_remove_colony(world, tracked_id);
+    ASSERT_NULL(world_get_colony(world, tracked_id));
+    ASSERT_EQ(world->cells[tracked_a].colony_id, 0u);
+    ASSERT_EQ(world->cells[tracked_b].colony_id, 0u);
+    ASSERT_EQ(world->cells[tracked_a].age, 0);
+    ASSERT_EQ(world->cells[tracked_b].age, 0);
+    ASSERT_NULL(tracked->cell_indices);
+    ASSERT_EQ(tracked->cell_indices_count, 0u);
+
+    world_remove_colony(world, scan_id);
+    ASSERT_NULL(world_get_colony(world, scan_id));
+    ASSERT_EQ(world->cells[scan_a].colony_id, 0u);
+    ASSERT_EQ(world->cells[scan_b].colony_id, 0u);
+    ASSERT_EQ(world->cells[scan_a].age, 0);
+    ASSERT_EQ(world->cells[scan_b].age, 0);
+
+    world_remove_colony(world, UINT32_MAX);
+    world_remove_colony(world, 0);
+
+    world_destroy(world);
+}
+
+int main(void) {
+    printf("=== World Branch Coverage Tests ===\n");
+
+    RUN_TEST(world_create_rejects_invalid_sizes);
+    RUN_TEST(world_get_colony_checks_lookup_and_active_state);
+    RUN_TEST(world_add_colony_rejects_uint32_id_overflow);
+    RUN_TEST(world_colony_cell_tracking_updates_centroid_both_paths);
+    RUN_TEST(world_remove_colony_uses_tracked_and_fallback_clear_paths);
+
+    printf("Passed: %d\n", tests_passed);
+    printf("Failed: %d\n", tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- Adds deterministic, high-impact branch coverage tests for `src/server/world.c` via new `test_world_branch_coverage` cases focused on invalid world creation, colony lookup activity checks, ID-overflow rejection, centroid tracking, and both tracked/fallback colony removal paths.
- Adds deterministic server branch coverage tests for `src/server/server.c` via new `test_server_branch_coverage` cases covering command-branch behavior (speed clamp boundaries, reset world rebuild, select/spawn data branches), client removal no-op path, client-processing skip paths, and `server_stop`/`server_get_port` guard branches.
- Registers both executables in `tests/CMakeLists.txt` as `WorldBranchCoverageTests` and `ServerBranchCoverageTests`.

## Validation
- `cmake -S . -B build-tests-world-server`
- `cmake --build build-tests-world-server --target test_world_branch_coverage test_server_branch_coverage`
- `ctest --test-dir build-tests-world-server --output-on-failure -R "WorldBranchCoverageTests|ServerBranchCoverageTests"`
- Result: `100% tests passed, 0 tests failed out of 2`.

## Issue
- Closes #28