### PR TITLE
Add branch-focused protocol and parallel edge coverage

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,6 +64,12 @@ target_link_libraries(test_protocol_edge PRIVATE ferox_server_lib)
 target_compile_definitions(test_protocol_edge PRIVATE STANDALONE_TEST)
 add_test(NAME ProtocolEdgeTests COMMAND test_protocol_edge)
 
+# Parallel orchestration edge branch tests
+add_executable(test_parallel_edge test_parallel_edge.c)
+target_link_libraries(test_parallel_edge PRIVATE ferox_server_lib)
+target_compile_definitions(test_parallel_edge PRIVATE STANDALONE_TEST)
+add_test(NAME ParallelEdgeTests COMMAND test_parallel_edge)
+
 # Exhaustive name tests
 add_executable(test_names_exhaustive test_names_exhaustive.c)
 target_link_libraries(test_names_exhaustive PRIVATE ferox_shared)

--- a/tests/test_parallel_edge.c
+++ b/tests/test_parallel_edge.c
@@ -1,0 +1,169 @@
+/**
+ * test_parallel_edge.c - Branch-focused tests for parallel orchestration
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+
+#include "../src/server/threadpool.h"
+#include "../src/server/parallel.h"
+#include "../src/server/simulation.h"
+#include "../src/server/world.h"
+
+#define TEST_START(name) printf("  Testing %s... ", name)
+#define TEST_PASS() printf("PASSED\n")
+#define TEST_FAIL(msg) do { printf("FAILED: %s\n", msg); return 1; } while (0)
+
+#define ASSERT_TRUE(cond) do { if (!(cond)) TEST_FAIL(#cond " is false"); } while (0)
+#define ASSERT_EQ(a, b) do { if ((a) != (b)) TEST_FAIL(#a " != " #b); } while (0)
+#define ASSERT_NOT_NULL(ptr) do { if ((ptr) == NULL) TEST_FAIL(#ptr " is NULL"); } while (0)
+
+static void increment_task(void* arg) {
+    int* counter = (int*)arg;
+    (*counter)++;
+}
+
+static int test_threadpool_submit_handles_null_inputs(void) {
+    TEST_START("threadpool_submit null inputs");
+
+    int counter = 0;
+    threadpool_submit(NULL, increment_task, &counter);
+
+    ThreadPool* pool = threadpool_create(1);
+    ASSERT_NOT_NULL(pool);
+
+    threadpool_submit(pool, NULL, &counter);
+    threadpool_wait(pool);
+    ASSERT_EQ(counter, 0);
+
+    threadpool_destroy(pool);
+    TEST_PASS();
+    return 0;
+}
+
+static int test_threadpool_submit_ignored_during_shutdown(void) {
+    TEST_START("threadpool_submit shutdown branch");
+
+    ThreadPool* pool = threadpool_create(1);
+    ASSERT_NOT_NULL(pool);
+
+    int counter = 0;
+
+    pthread_mutex_lock(&pool->queue_mutex);
+    pool->shutdown = true;
+    pthread_mutex_unlock(&pool->queue_mutex);
+
+    threadpool_submit(pool, increment_task, &counter);
+    threadpool_wait(pool);
+    ASSERT_EQ(counter, 0);
+
+    threadpool_destroy(pool);
+    TEST_PASS();
+    return 0;
+}
+
+static int test_parallel_init_regions_ignores_invalid_dimensions(void) {
+    TEST_START("parallel_init_regions invalid dimensions");
+
+    ThreadPool* pool = threadpool_create(1);
+    ASSERT_NOT_NULL(pool);
+    ParallelContext* ctx = parallel_create(pool, NULL, 2, 2);
+    ASSERT_NOT_NULL(ctx);
+
+    parallel_init_regions(ctx, 0, 10);
+    ASSERT_EQ(ctx->regions[0].end_x, 0);
+    ASSERT_EQ(ctx->regions[0].end_y, 0);
+
+    parallel_init_regions(ctx, 10, -1);
+    ASSERT_EQ(ctx->regions[1].end_x, 0);
+    ASSERT_EQ(ctx->regions[1].end_y, 0);
+
+    parallel_destroy(ctx);
+    threadpool_destroy(pool);
+    TEST_PASS();
+    return 0;
+}
+
+static int test_parallel_api_handles_null_context(void) {
+    TEST_START("parallel APIs handle NULL context");
+
+    parallel_age(NULL);
+    parallel_spread(NULL);
+    parallel_mutate(NULL);
+    parallel_barrier(NULL);
+    parallel_init_regions(NULL, 10, 10);
+    parallel_tick(NULL);
+    threadpool_wait(NULL);
+    threadpool_destroy(NULL);
+
+    TEST_PASS();
+    return 0;
+}
+
+static int test_parallel_tick_returns_when_world_is_null(void) {
+    TEST_START("parallel_tick world NULL");
+
+    ThreadPool* pool = threadpool_create(2);
+    ASSERT_NOT_NULL(pool);
+    ParallelContext* ctx = parallel_create(pool, NULL, 1, 1);
+    ASSERT_NOT_NULL(ctx);
+
+    parallel_tick(ctx);
+
+    ASSERT_EQ(pool->pending_tasks, 0);
+    ASSERT_EQ(pool->active_tasks, 0);
+
+    parallel_destroy(ctx);
+    threadpool_destroy(pool);
+    TEST_PASS();
+    return 0;
+}
+
+static int test_parallel_spread_skips_null_pending_buffer(void) {
+    TEST_START("parallel_spread skips NULL pending buffer");
+
+    ThreadPool* pool = threadpool_create(2);
+    ASSERT_NOT_NULL(pool);
+    World* world = world_create(4, 4);
+    ASSERT_NOT_NULL(world);
+    ParallelContext* ctx = parallel_create(pool, world, 1, 1);
+    ASSERT_NOT_NULL(ctx);
+
+    parallel_init_regions(ctx, world->width, world->height);
+
+    pending_buffer_destroy(ctx->pending_buffers[0]);
+    ctx->pending_buffers[0] = NULL;
+
+    parallel_spread(ctx);
+    parallel_barrier(ctx);
+    ASSERT_TRUE(ctx->pending_buffers[0] == NULL);
+
+    parallel_destroy(ctx);
+    world_destroy(world);
+    threadpool_destroy(pool);
+    TEST_PASS();
+    return 0;
+}
+
+int main(void) {
+    int failed = 0;
+
+    printf("\n=== Parallel Edge Branch Tests ===\n\n");
+
+    failed += test_threadpool_submit_handles_null_inputs();
+    failed += test_threadpool_submit_ignored_during_shutdown();
+    failed += test_parallel_init_regions_ignores_invalid_dimensions();
+    failed += test_parallel_api_handles_null_context();
+    failed += test_parallel_tick_returns_when_world_is_null();
+    failed += test_parallel_spread_skips_null_pending_buffer();
+
+    printf("\n=== Results ===\n");
+    if (failed == 0) {
+        printf("All tests PASSED!\n");
+        return 0;
+    }
+
+    printf("%d test(s) FAILED!\n", failed);
+    return 1;
+}

--- a/tests/test_protocol_edge.c
+++ b/tests/test_protocol_edge.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <math.h>
+#include <arpa/inet.h>
 
 #include "../src/shared/protocol.h"
 
@@ -38,6 +39,12 @@ static int tests_failed = 0;
 #define ASSERT_GE(a, b) ASSERT((a) >= (b), #a " >= " #b)
 #define ASSERT_LE(a, b) ASSERT((a) <= (b), #a " <= " #b)
 #define ASSERT_NOT_NULL(ptr) ASSERT((ptr) != NULL, #ptr " is not NULL")
+#define ASSERT_FALSE(cond) ASSERT(!(cond), "Expected condition to be false: " #cond)
+
+static void write_u32_be(uint8_t* buffer, uint32_t value) {
+    uint32_t net = htonl(value);
+    memcpy(buffer, &net, sizeof(net));
+}
 
 // ============================================================================
 // Empty World Tests
@@ -258,6 +265,86 @@ TEST(partial_message_handling) {
     free(buffer);
 }
 
+TEST(rejects_world_state_with_too_many_colonies) {
+    proto_world world;
+    memset(&world, 0, sizeof(proto_world));
+    world.width = 8;
+    world.height = 8;
+
+    uint8_t* buffer = NULL;
+    size_t len = 0;
+
+    int result = protocol_serialize_world_state(&world, &buffer, &len);
+    ASSERT_EQ(result, 0);
+    ASSERT_GE(len, 26);
+
+    write_u32_be(buffer + 12, MAX_COLONIES + 1);
+
+    proto_world deserialized;
+    memset(&deserialized, 0, sizeof(proto_world));
+    result = protocol_deserialize_world_state(buffer, len, &deserialized);
+    ASSERT_EQ(result, -1);
+
+    free(buffer);
+}
+
+TEST(grid_metadata_out_of_bounds_disables_grid) {
+    proto_world world;
+    memset(&world, 0, sizeof(proto_world));
+    world.width = 5;
+    world.height = 5;
+
+    uint8_t* buffer = NULL;
+    size_t len = 0;
+
+    int result = protocol_serialize_world_state(&world, &buffer, &len);
+    ASSERT_EQ(result, 0);
+    ASSERT_GE(len, 26);
+
+    buffer[21] = 1;
+    write_u32_be(buffer + 22, 10);
+
+    proto_world deserialized;
+    memset(&deserialized, 0, sizeof(proto_world));
+    result = protocol_deserialize_world_state(buffer, len, &deserialized);
+    ASSERT_EQ(result, 0);
+    ASSERT_FALSE(deserialized.has_grid);
+    ASSERT_EQ(deserialized.grid, NULL);
+    ASSERT_EQ(deserialized.grid_size, 0);
+
+    free(buffer);
+}
+
+TEST(invalid_rle_payload_disables_grid) {
+    proto_world world;
+    memset(&world, 0, sizeof(proto_world));
+    world.width = 2;
+    world.height = 2;
+    world.has_grid = true;
+    world.grid_size = 4;
+
+    uint16_t grid_data[4] = {1, 1, 1, 1};
+    world.grid = grid_data;
+
+    uint8_t* buffer = NULL;
+    size_t len = 0;
+
+    int result = protocol_serialize_world_state(&world, &buffer, &len);
+    ASSERT_EQ(result, 0);
+    ASSERT(buffer[21] == 1, "Serialized world should include grid data");
+
+    write_u32_be(buffer + 26, 9999);
+
+    proto_world deserialized;
+    memset(&deserialized, 0, sizeof(proto_world));
+    result = protocol_deserialize_world_state(buffer, len, &deserialized);
+    ASSERT_EQ(result, 0);
+    ASSERT_FALSE(deserialized.has_grid);
+
+    proto_world_free(&deserialized);
+    free(buffer);
+}
+
 // ============================================================================
 // Colony Name Tests
 // ============================================================================
@@ -413,6 +500,14 @@ TEST(rejects_truncated_command_payload) {
     ASSERT_EQ(protocol_deserialize_command(buffer, 8, &cmd, NULL), -1);
 }
 
+TEST(rejects_unknown_command_type) {
+    uint8_t buffer[4];
+    CommandType cmd;
+
+    write_u32_be(buffer, 999);
+    ASSERT_EQ(protocol_deserialize_command(buffer, sizeof(buffer), &cmd, NULL), -1);
+}
+
 // ============================================================================
 // Null Input Tests
 // ============================================================================
@@ -517,6 +612,9 @@ int run_protocol_edge_tests(void) {
     printf("\nPayload Tests:\n");
     RUN_TEST(zero_length_payload);
     RUN_TEST(partial_message_handling);
+    RUN_TEST(rejects_world_state_with_too_many_colonies);
+    RUN_TEST(grid_metadata_out_of_bounds_disables_grid);
+    RUN_TEST(invalid_rle_payload_disables_grid);
     
     printf("\nColony Name Tests:\n");
     RUN_TEST(maximum_length_colony_name);
@@ -529,6 +627,7 @@ int run_protocol_edge_tests(void) {
     RUN_TEST(select_colony_command);
     RUN_TEST(spawn_colony_command);
     RUN_TEST(rejects_truncated_command_payload);
+    RUN_TEST(rejects_unknown_command_type);
     
     printf("\nNull Input Tests:\n");
     RUN_TEST(null_inputs_handled);


### PR DESCRIPTION
## Summary
- Add protocol branch tests for oversized colony metadata, grid metadata bounds, invalid grid RLE payloads, and unknown command rejection.
- Add dedicated parallel/threadpool edge tests for null guards, shutdown submission rejection, invalid region init dimensions, and null pending-buffer spread tasks.
- Register the new parallel edge suite in CMake and keep all scenarios deterministic for CI.

## Validation
- `ctest --test-dir build -R "(ProtocolEdgeTests|ParallelEdgeTests)" --output-on-failure`

Closes #27