### PR TITLE
ci: generate preview gif only after successful PR CI

### DIFF
--- a/.github/workflows/update-preview-gif.yml
+++ b/.github/workflows/update-preview-gif.yml
@@ -25,21 +25,24 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             BRANCH="${GITHUB_REF_NAME}"
+            REF="$BRANCH"
           else
             BRANCH="${{ github.event.workflow_run.head_branch }}"
+            REF="${{ github.event.workflow_run.head_sha }}"
           fi
 
-          if [ -z "$BRANCH" ]; then
-            echo "Unable to determine target branch"
+          if [ -z "$BRANCH" ] || [ -z "$REF" ]; then
+            echo "Unable to determine target branch/ref"
             exit 1
           fi
 
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
 
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ steps.target.outputs.branch }}
+          ref: ${{ steps.target.outputs.ref }}
           persist-credentials: true
 
       - name: Install uv


### PR DESCRIPTION
## Summary
- switch preview GIF workflow trigger from push-to-main to workflow_run on successful CI runs for pull requests
- target the PR head branch and push the generated assets/preview.gif commit there
- keep workflow_dispatch support for manual runs

## Why
- protected main blocks bot pushes, so push-triggered auto-commit fails
- this aligns generation with your requested flow: only update the image after tests pass on a PR

## Behavior
- when PR CI succeeds, preview workflow runs and commits GIF updates to that PR branch
- this may trigger one additional CI run for the GIF commit; subsequent preview runs should no-op if unchanged

## Validation
- inspected failed run 22297619608 showing protected-branch push rejection to main
- updated workflow to avoid direct pushes to protected main