### PR TITLE
perf: optimize world-state broadcast build path

### DIFF
--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -22,6 +22,7 @@ Average values from repeated runs:
 - Name + color generation: **39.6 ms** for 250k iterations
 - World create/init/destroy: **32.8 ms** for 900 iterations
 - Protocol serialize+deserialize: **24.0 ms** for 600 iterations (**630.6 MB/s**)
+- Broadcast path breakdown metrics now emitted (`build snapshot`, `build+serialize`, `end-to-end (0 clients)`, plus stage-share percentages)
 - `simulation_tick` (serial): **533 ms** for 175 ticks (~3.0 ms/tick)
 - `atomic_tick` (4 threads): **1299 ms** for 150 ticks (~8.7 ms/tick)
 - Atomic vs serial ratio: **2.19x** (atomic path still slower; see notes)
@@ -58,6 +59,11 @@ Average values from repeated runs:
 - World state serialization writes grid directly into message buffer (no intermediate copy).
 - Deserialize zero-fill uses `memset` instead of scalar loop.
 
+### ✅ Broadcast/protocol build-path optimization
+- `server_build_protocol_world_snapshot()` now folds grid copy + centroid accumulation into one pass.
+- Removed per-broadcast heap allocations for centroid accumulation (stack-backed fixed arrays).
+- Replaced per-cell colony lookup + division/modulo work with binary-search id mapping and row/column iteration.
+
 ## Remaining Bottlenecks
 
 ### 1) Atomic tick path still slower than serial
@@ -89,4 +95,3 @@ If deeper profiling is needed beyond built-in tests:
 - **Linux**: `perf`, `heaptrack`, `valgrind --tool=callgrind`
 
 Built-in performance tests are great for regression tracking; external profilers are better for precise flamegraph hotspot attribution.
-

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -24,6 +24,39 @@ static void* accept_thread_func(void* arg);
 static void* simulation_thread_func(void* arg);
 static bool server_rebuild_world_state(Server* server, int width, int height, int initial_colonies);
 
+typedef struct {
+    uint32_t colony_id;
+    uint16_t proto_idx;
+} colony_proto_index;
+
+static int compare_colony_proto_index(const void* a, const void* b) {
+    const colony_proto_index* ia = (const colony_proto_index*)a;
+    const colony_proto_index* ib = (const colony_proto_index*)b;
+    if (ia->colony_id < ib->colony_id) return -1;
+    if (ia->colony_id > ib->colony_id) return 1;
+    return 0;
+}
+
+static int32_t find_proto_index_for_colony(const colony_proto_index* lookup, uint32_t count, uint32_t colony_id) {
+    uint32_t lo = 0;
+    uint32_t hi = count;
+
+    while (lo < hi) {
+        uint32_t mid = lo + (hi - lo) / 2;
+        uint32_t mid_id = lookup[mid].colony_id;
+        if (mid_id == colony_id) {
+            return (int32_t)lookup[mid].proto_idx;
+        }
+        if (mid_id < colony_id) {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+
+    return -1;
+}
+
 // Helper to get current time in milliseconds
 static long get_time_ms(void) {
     struct timespec ts;
@@ -327,55 +360,41 @@ static bool server_rebuild_world_state(Server* server, int width, int height, in
 }
 
 // Convert internal World/Colony to protocol proto_world for serialization
-static void build_protocol_world(Server* server, proto_world* proto_world) {
-    proto_world_init(proto_world);
+void server_build_protocol_world_snapshot(Server* server, proto_world* out_world) {
+    if (!out_world) return;
+    proto_world_init(out_world);
+    if (!server || !server->world) return;
     World* world = server->world;
-    
-    proto_world->width = (uint32_t)world->width;
-    proto_world->height = (uint32_t)world->height;
-    proto_world->tick = (uint32_t)world->tick;
-    proto_world->paused = server->paused;
-    proto_world->speed_multiplier = server->speed_multiplier;
-    
-    // Build grid data from world cells
-    uint32_t grid_size = proto_world->width * proto_world->height;
-    if (grid_size > 0 && grid_size <= MAX_GRID_SIZE) {
-        proto_world_alloc_grid(proto_world, proto_world->width, proto_world->height);
-        if (proto_world->grid) {
-            for (uint32_t i = 0; i < grid_size; i++) {
-                proto_world->grid[i] = (uint16_t)world->cells[i].colony_id;
-            }
-        }
-    }
 
-    int32_t* world_idx_to_proto = NULL;
-    if (world->colony_count > 0) {
-        world_idx_to_proto = (int32_t*)malloc(world->colony_count * sizeof(int32_t));
-        if (world_idx_to_proto) {
-            for (size_t i = 0; i < world->colony_count; i++) {
-                world_idx_to_proto[i] = -1;
-            }
-        }
-    }
-    
-    // Build protocol colony list and world-index mapping.
+    out_world->width = (uint32_t)world->width;
+    out_world->height = (uint32_t)world->height;
+    out_world->tick = (uint32_t)world->tick;
+    out_world->paused = server->paused;
+    out_world->speed_multiplier = server->speed_multiplier;
+
+    const uint32_t width = out_world->width;
+    const uint32_t height = out_world->height;
+    const size_t grid_size = (size_t)width * (size_t)height;
+
+    // Build protocol colony list and id->protocol index mapping.
     uint32_t count = 0;
+    colony_proto_index colony_lookup[MAX_COLONIES];
+
     for (size_t i = 0; i < world->colony_count && count < MAX_COLONIES; i++) {
         if (world->colonies[i].active) {
-            proto_colony* proto_colony = &proto_world->colonies[count];
-            
+            proto_colony* proto_colony = &out_world->colonies[count];
+
             // Map fields from internal Colony (types.h) to protocol proto_colony
             proto_colony->id = world->colonies[i].id;
             strncpy(proto_colony->name, world->colonies[i].name, MAX_COLONY_NAME - 1);
             proto_colony->name[MAX_COLONY_NAME - 1] = '\0';
 
-            if (world_idx_to_proto) {
-                world_idx_to_proto[i] = (int32_t)count;
-            }
+            colony_lookup[count].colony_id = proto_colony->id;
+            colony_lookup[count].proto_idx = (uint16_t)count;
 
             proto_colony->x = world->colonies[i].centroid_x;
             proto_colony->y = world->colonies[i].centroid_y;
-            
+
             proto_colony->population = (uint32_t)world->colonies[i].cell_count;
             proto_colony->max_population = (uint32_t)world->colonies[i].max_cell_count;
             proto_colony->radius = (float)world->colonies[i].cell_count / 3.14159f;
@@ -397,52 +416,61 @@ static void build_protocol_world(Server* server, proto_world* proto_world) {
             proto_colony->metabolism = world->colonies[i].genome.metabolism;
             proto_colony->toxin_production = world->colonies[i].genome.toxin_production;
             proto_colony->spread_rate = world->colonies[i].genome.spread_rate;
-            
+
             count++;
         }
     }
 
-    if (count > 0 && world_idx_to_proto) {
-        double* sum_x = (double*)calloc(count, sizeof(double));
-        double* sum_y = (double*)calloc(count, sizeof(double));
-        uint32_t* pop = (uint32_t*)calloc(count, sizeof(uint32_t));
+    bool has_sorted_lookup = false;
+    if (count > 0) {
+        qsort(colony_lookup, count, sizeof(colony_lookup[0]), compare_colony_proto_index);
+        has_sorted_lookup = true;
+    }
 
-        if (sum_x && sum_y && pop) {
-            for (uint32_t i = 0; i < grid_size; i++) {
-                uint32_t colony_id = world->cells[i].colony_id;
+    if (grid_size > 0 && grid_size <= MAX_GRID_SIZE) {
+        proto_world_alloc_grid(out_world, width, height);
+    }
+
+    if (grid_size > 0 && has_sorted_lookup) {
+        double sum_x[MAX_COLONIES] = {0};
+        double sum_y[MAX_COLONIES] = {0};
+        uint32_t pop[MAX_COLONIES] = {0};
+
+        for (uint32_t y = 0; y < height; y++) {
+            size_t row_start = (size_t)y * (size_t)width;
+            for (uint32_t x = 0; x < width; x++) {
+                size_t idx = row_start + (size_t)x;
+                uint32_t colony_id = world->cells[idx].colony_id;
+
+                if (out_world->grid) {
+                    out_world->grid[idx] = (uint16_t)colony_id;
+                }
+
                 if (colony_id == 0) continue;
 
-                Colony* colony = world_get_colony(world, colony_id);
-                if (!colony) continue;
-
-                size_t world_idx = (size_t)(colony - world->colonies);
-                if (world_idx >= world->colony_count) continue;
-
-                int32_t proto_idx = world_idx_to_proto[world_idx];
+                int32_t proto_idx = find_proto_index_for_colony(colony_lookup, count, colony_id);
                 if (proto_idx < 0) continue;
 
                 uint32_t pidx = (uint32_t)proto_idx;
                 pop[pidx]++;
-                sum_x[pidx] += (double)(i % proto_world->width);
-                sum_y[pidx] += (double)(i / proto_world->width);
-            }
-
-            for (uint32_t i = 0; i < count; i++) {
-                if (pop[i] > 0) {
-                    proto_world->colonies[i].x = (float)(sum_x[i] / (double)pop[i]);
-                    proto_world->colonies[i].y = (float)(sum_y[i] / (double)pop[i]);
-                }
+                sum_x[pidx] += (double)x;
+                sum_y[pidx] += (double)y;
             }
         }
 
-        free(pop);
-        free(sum_y);
-        free(sum_x);
+        for (uint32_t i = 0; i < count; i++) {
+            if (pop[i] > 0) {
+                out_world->colonies[i].x = (float)(sum_x[i] / (double)pop[i]);
+                out_world->colonies[i].y = (float)(sum_y[i] / (double)pop[i]);
+            }
+        }
+    } else if (out_world->grid) {
+        for (size_t i = 0; i < grid_size; i++) {
+            out_world->grid[i] = (uint16_t)world->cells[i].colony_id;
+        }
     }
 
-    free(world_idx_to_proto);
-
-    proto_world->colony_count = count;
+    out_world->colony_count = count;
 }
 
 void server_broadcast_world_state(Server* server) {
@@ -450,7 +478,7 @@ void server_broadcast_world_state(Server* server) {
     
     // Build protocol world state
     proto_world proto_world;
-    build_protocol_world(server, &proto_world);
+    server_build_protocol_world_snapshot(server, &proto_world);
     
     // Serialize
     uint8_t* buffer = NULL;

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -85,6 +85,13 @@ void server_stop(Server* server);
 void server_broadcast_world_state(Server* server);
 
 /**
+ * Build a protocol snapshot from the current server world state.
+ * @param server The server
+ * @param out_world Destination protocol world (must be freed with proto_world_free)
+ */
+void server_build_protocol_world_snapshot(Server* server, proto_world* out_world);
+
+/**
  * Send detailed colony info to a specific client.
  * @param server The server
  * @param client The client session

--- a/tests/test_performance_eval.c
+++ b/tests/test_performance_eval.c
@@ -17,6 +17,7 @@
 #include "../src/server/world.h"
 #include "../src/server/genetics.h"
 #include "../src/server/simulation.h"
+#include "../src/server/server.h"
 #include "../src/server/threadpool.h"
 #include "../src/server/atomic_sim.h"
 
@@ -272,6 +273,75 @@ TEST(protocol_world_path_breakdown_eval) {
     proto_world_free(&world);
 }
 
+TEST(server_broadcast_path_breakdown_eval) {
+    const int scale = get_perf_scale();
+    const int iters = 80 * scale;
+
+    Server* server = server_create(0, 320, 180, 4);
+    ASSERT_NOT_NULL(server);
+
+    rng_seed(1337);
+    world_init_random_colonies(server->world, 72);
+    for (int i = 0; i < 3; i++) {
+        simulation_tick(server->world);
+    }
+
+    size_t total_snapshot_bytes = 0;
+    double build_start = now_ms();
+    for (int i = 0; i < iters; i++) {
+        proto_world snapshot;
+        server_build_protocol_world_snapshot(server, &snapshot);
+        total_snapshot_bytes += (size_t)snapshot.colony_count * COLONY_SERIALIZED_SIZE;
+        total_snapshot_bytes += (size_t)snapshot.grid_size * sizeof(uint16_t);
+        proto_world_free(&snapshot);
+    }
+    double build_ms = now_ms() - build_start;
+
+    size_t total_encoded_bytes = 0;
+    double build_serialize_start = now_ms();
+    for (int i = 0; i < iters; i++) {
+        proto_world snapshot;
+        server_build_protocol_world_snapshot(server, &snapshot);
+
+        uint8_t* encoded = NULL;
+        size_t encoded_len = 0;
+        int rc = protocol_serialize_world_state(&snapshot, &encoded, &encoded_len);
+        ASSERT_EQ(rc, 0);
+        ASSERT_NOT_NULL(encoded);
+
+        total_encoded_bytes += encoded_len;
+
+        free(encoded);
+        proto_world_free(&snapshot);
+    }
+    double build_serialize_ms = now_ms() - build_serialize_start;
+
+    double broadcast_start = now_ms();
+    for (int i = 0; i < iters; i++) {
+        server_broadcast_world_state(server);
+    }
+    double broadcast_ms = now_ms() - broadcast_start;
+
+    print_metric("broadcast build snapshot", build_ms, (double)iters);
+    print_metric("broadcast build+serialize", build_serialize_ms, (double)iters);
+    print_metric("broadcast end-to-end (0 clients)", broadcast_ms, (double)iters);
+
+    double avg_snapshot_kb = (double)total_snapshot_bytes / (double)iters / 1024.0;
+    double avg_encoded_kb = (double)total_encoded_bytes / (double)iters / 1024.0;
+    printf("    [perf] broadcast avg snapshot: %.2f KiB, encoded: %.2f KiB\n", avg_snapshot_kb, avg_encoded_kb);
+
+    if (build_serialize_ms > 0.0) {
+        double build_share = (build_ms / build_serialize_ms) * 100.0;
+        printf("    [perf] broadcast stage share: build=%.1f%% serialize+other=%.1f%%\n",
+               build_share, 100.0 - build_share);
+    }
+
+    ASSERT(build_ms > 0.0 && build_serialize_ms > 0.0 && broadcast_ms > 0.0,
+           "broadcast timings must be positive");
+
+    server_destroy(server);
+}
+
 TEST(simulation_tick_throughput) {
     const int scale = get_perf_scale();
     const int ticks = 35 * scale;
@@ -462,6 +532,7 @@ int run_performance_eval_tests(void) {
     RUN_TEST(world_lifecycle_throughput);
     RUN_TEST(protocol_world_serialize_deserialize_throughput);
     RUN_TEST(protocol_world_path_breakdown_eval);
+    RUN_TEST(server_broadcast_path_breakdown_eval);
     RUN_TEST(simulation_tick_throughput);
     RUN_TEST(atomic_tick_throughput_and_speedup_eval);
     RUN_TEST(atomic_tick_thread_scaling_eval);


### PR DESCRIPTION
## Summary
- Optimize server world-state snapshot construction by folding grid copy and centroid accumulation into one pass and removing per-broadcast heap allocations.
- Expose `server_build_protocol_world_snapshot()` so perf tests can measure snapshot build vs serialize vs end-to-end broadcast stages.
- Extend `PerformanceEvalTests` with a broadcast-path breakdown benchmark and document the new broadcast-stage metrics in performance docs.

## Testing
- `cmake -S . -B build && cmake --build build -j`
- `ctest --output-on-failure -R "PerformanceEvalTests|ProtocolEdgeTests|Phase4Tests|Phase5Tests|Phase6Tests"`
- `ctest -V -R PerformanceEvalTests`

Closes #42

@codex please review the broadcast/protocol-path optimization and benchmark breakdown coverage in this PR.