### PR TITLE
ci: add statistical regression checks for simulation outputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,52 @@ jobs:
           echo "run_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> "$GITHUB_OUTPUT"
           exit "$test_exit_code"
 
+      - name: Run simulation statistical regression report
+        id: stat_regression
+        shell: bash
+        run: |
+          set +e
+          cd build
+          ctest --output-on-failure --timeout 600 -C "${{ matrix.build_type }}" -R "SimulationStatRegressionTests" -V | tee stat-regression.log
+          stat_exit_code=${PIPESTATUS[0]}
+          python3 - <<'PY'
+          import os
+          import re
+
+          metrics = []
+          status = "passed"
+          log_path = "stat-regression.log"
+          pattern = re.compile(
+              r"STAT_REGRESSION metric=(?P<metric>\S+) mean=(?P<mean>[-+0-9.eE]+) stddev=(?P<stddev>[-+0-9.eE]+) "
+              r"min=(?P<min>[-+0-9.eE]+) max=(?P<max>[-+0-9.eE]+) expected_mean=(?P<expected_mean>[-+0-9.eE]+) "
+              r"mean_tol=(?P<mean_tol>[-+0-9.eE]+) expected_stddev=(?P<expected_stddev>[-+0-9.eE]+) "
+              r"stddev_tol=(?P<stddev_tol>[-+0-9.eE]+)"
+          )
+
+          try:
+              with open(log_path, "r", encoding="utf-8", errors="ignore") as f:
+                  log_text = f.read()
+              for line in log_text.splitlines():
+                  m = pattern.search(line)
+                  if m:
+                      metrics.append(m.groupdict())
+              if "Simulation Statistical Regression: FAILED" in log_text or not metrics:
+                  status = "failed"
+          except FileNotFoundError:
+              status = "failed"
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
+              out.write(f"status={status}\n")
+              out.write(f"metrics_count={len(metrics)}\n")
+              for metric in metrics:
+                  key = metric["metric"]
+                  out.write(f"{key}_mean={metric['mean']}\n")
+                  out.write(f"{key}_stddev={metric['stddev']}\n")
+                  out.write(f"{key}_min={metric['min']}\n")
+                  out.write(f"{key}_max={metric['max']}\n")
+          PY
+          exit "$stat_exit_code"
+
       - name: Summarize test results
         if: always()
         run: |
@@ -91,6 +137,11 @@ jobs:
           - Passed: ${{ steps.run_tests.outputs.passed || '0' }}
           - Failed: ${{ steps.run_tests.outputs.failed || '0' }}
           - Total: ${{ steps.run_tests.outputs.total || '0' }}
+          - Statistical regression: **${{ steps.stat_regression.outputs.status || 'failed' }}**
+          - Statistical metrics captured: ${{ steps.stat_regression.outputs.metrics_count || '0' }}
+          - occupied_ratio: mean=${{ steps.stat_regression.outputs.occupied_ratio_mean || 'n/a' }}, stddev=${{ steps.stat_regression.outputs.occupied_ratio_stddev || 'n/a' }}
+          - active_colonies: mean=${{ steps.stat_regression.outputs.active_colonies_mean || 'n/a' }}, stddev=${{ steps.stat_regression.outputs.active_colonies_stddev || 'n/a' }}
+          - dominant_share: mean=${{ steps.stat_regression.outputs.dominant_share_mean || 'n/a' }}, stddev=${{ steps.stat_regression.outputs.dominant_share_stddev || 'n/a' }}
           - Details: ${{ steps.run_tests.outputs.run_url || format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
           EOF
 
@@ -165,6 +216,52 @@ jobs:
           echo "run_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> "$GITHUB_OUTPUT"
           exit "$test_exit_code"
 
+      - name: Run simulation statistical regression report
+        id: stat_regression
+        shell: bash
+        run: |
+          set +e
+          cd build
+          ctest --output-on-failure --timeout 600 -C "${{ matrix.build_type }}" -R "SimulationStatRegressionTests" -V | tee stat-regression.log
+          stat_exit_code=${PIPESTATUS[0]}
+          python3 - <<'PY'
+          import os
+          import re
+
+          metrics = []
+          status = "passed"
+          log_path = "stat-regression.log"
+          pattern = re.compile(
+              r"STAT_REGRESSION metric=(?P<metric>\S+) mean=(?P<mean>[-+0-9.eE]+) stddev=(?P<stddev>[-+0-9.eE]+) "
+              r"min=(?P<min>[-+0-9.eE]+) max=(?P<max>[-+0-9.eE]+) expected_mean=(?P<expected_mean>[-+0-9.eE]+) "
+              r"mean_tol=(?P<mean_tol>[-+0-9.eE]+) expected_stddev=(?P<expected_stddev>[-+0-9.eE]+) "
+              r"stddev_tol=(?P<stddev_tol>[-+0-9.eE]+)"
+          )
+
+          try:
+              with open(log_path, "r", encoding="utf-8", errors="ignore") as f:
+                  log_text = f.read()
+              for line in log_text.splitlines():
+                  m = pattern.search(line)
+                  if m:
+                      metrics.append(m.groupdict())
+              if "Simulation Statistical Regression: FAILED" in log_text or not metrics:
+                  status = "failed"
+          except FileNotFoundError:
+              status = "failed"
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
+              out.write(f"status={status}\n")
+              out.write(f"metrics_count={len(metrics)}\n")
+              for metric in metrics:
+                  key = metric["metric"]
+                  out.write(f"{key}_mean={metric['mean']}\n")
+                  out.write(f"{key}_stddev={metric['stddev']}\n")
+                  out.write(f"{key}_min={metric['min']}\n")
+                  out.write(f"{key}_max={metric['max']}\n")
+          PY
+          exit "$stat_exit_code"
+
       - name: Summarize test results
         if: always()
         run: |
@@ -174,6 +271,11 @@ jobs:
           - Passed: ${{ steps.run_tests.outputs.passed || '0' }}
           - Failed: ${{ steps.run_tests.outputs.failed || '0' }}
           - Total: ${{ steps.run_tests.outputs.total || '0' }}
+          - Statistical regression: **${{ steps.stat_regression.outputs.status || 'failed' }}**
+          - Statistical metrics captured: ${{ steps.stat_regression.outputs.metrics_count || '0' }}
+          - occupied_ratio: mean=${{ steps.stat_regression.outputs.occupied_ratio_mean || 'n/a' }}, stddev=${{ steps.stat_regression.outputs.occupied_ratio_stddev || 'n/a' }}
+          - active_colonies: mean=${{ steps.stat_regression.outputs.active_colonies_mean || 'n/a' }}, stddev=${{ steps.stat_regression.outputs.active_colonies_stddev || 'n/a' }}
+          - dominant_share: mean=${{ steps.stat_regression.outputs.dominant_share_mean || 'n/a' }}, stddev=${{ steps.stat_regression.outputs.dominant_share_stddev || 'n/a' }}
           - Details: ${{ steps.run_tests.outputs.run_url || format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
           EOF
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -230,6 +230,7 @@ ferox/
 - [API Reference](API.md) - Function documentation
 - [Science Bibliography](SCIENCE_BIBLIOGRAPHY.md) - DOI-backed research mapped to Ferox mechanics
 - [Testing](TESTING.md) - Test organization and coverage
+- [Statistical Regression](STATISTICAL_REGRESSION.md) - Multi-seed simulation drift checks and CI thresholds
 - [Contributing](CONTRIBUTING.md) - Development guidelines
 - [Self-Hosted Runner Ops](RUNNER_OPS.md) - Operations and incident response for CI runner
 

--- a/docs/STATISTICAL_REGRESSION.md
+++ b/docs/STATISTICAL_REGRESSION.md
@@ -1,0 +1,52 @@
+# Statistical Regression Testing
+
+This document defines the simulation statistical regression check added to CI for issue #57.
+
+## Goal
+
+Detect behavior drift in simulation outcomes without brittle one-seed exact snapshots.
+
+## Test Design
+
+- Test executable: `tests/test_simulation_stat_regression.c`
+- CTest target: `SimulationStatRegressionTests`
+- Batch configuration:
+  - 24 fixed seeds
+  - 96x64 world
+  - 14 initial colonies
+  - 90 ticks per seed
+- For each seed, we collect three metrics:
+  - `occupied_ratio`: occupied cells / total world cells
+  - `active_colonies`: active colonies with non-zero grid occupancy
+  - `dominant_share`: largest colony cells / total occupied cells
+
+The test computes distribution summaries for each metric (mean, stddev, min, max) and asserts mean/stddev against baseline thresholds.
+
+## Threshold Rationale
+
+Thresholds are anchored to current `origin/main` behavior and tuned to catch meaningful shifts while allowing normal stochastic spread:
+
+- `occupied_ratio`: baseline mean `0.954`, tolerance `+/- 0.060`; baseline stddev `0.032`, tolerance `+/- 0.030`
+- `active_colonies`: baseline mean `21.0`, tolerance `+/- 3.0`; baseline stddev `3.4`, tolerance `+/- 1.8`
+- `dominant_share`: baseline mean `0.171`, tolerance `+/- 0.050`; baseline stddev `0.038`, tolerance `+/- 0.025`
+
+These tolerances are intentionally wider than one-run noise because the simulation is stochastic and occasionally exhibits long-tail seed outcomes.
+
+## Anti-Flake Strategy
+
+The anti-flake approach is built into the measurement method:
+
+- Multi-seed aggregation (24 seeds) reduces any single outlier seed impact.
+- Distribution checks use both center (`mean`) and spread (`stddev`) instead of single-value snapshots.
+- Fixed seed set keeps the test reproducible and debuggable across hosts.
+- CI publishes metric summaries so drift can be triaged before tightening thresholds.
+
+## CI Integration
+
+`ci.yml` runs `SimulationStatRegressionTests` in both macOS and self-hosted Linux build jobs, then emits summary metrics in the GitHub Actions job summary.
+
+The test logs machine-parseable lines in this format:
+
+`STAT_REGRESSION metric=<name> mean=<v> stddev=<v> min=<v> max=<v> expected_mean=<v> mean_tol=<v> expected_stddev=<v> stddev_tol=<v>`
+
+This gives pass/fail and observability without relying on fragile golden output files.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -13,6 +13,7 @@ This document describes the test organization, how to run tests, and guidelines 
 - Client/server implementation
 - Visual stability (shape, radius, centroid)
 - Stress/performance testing
+- Statistical simulation regression testing (multi-seed distributions)
 
 ## Test Organization
 
@@ -29,6 +30,7 @@ tests/
 ├── test_genetics_advanced.c   # Extended genetics tests
 ├── test_world_advanced.c      # Extended world tests
 ├── test_simulation_logic.c    # Simulation correctness (38 tests)
+├── test_simulation_stat_regression.c # Multi-seed statistical regression checks
 ├── test_visual_stability.c    # Visual smoothness tests (4 tests)
 ├── test_simulation_stress.c   # Stress/performance tests
 ├── test_threadpool_stress.c   # Thread pool stress tests
@@ -420,6 +422,7 @@ CI is defined in `.github/workflows/ci.yml`:
 
 - `build-and-test-macos`: runs on `macos-latest` for `Release` and `Debug`.
 - `build-and-test-ferox`: runs on self-hosted labels `self-hosted`, `Linux`, `X64`, `ferox`, `rocky10` for `Release` and `Debug`.
+- Build jobs run `SimulationStatRegressionTests` and publish metric summaries in the GitHub Actions job summary.
 - `coverage-macos`: runs on `macos-latest` with `-DENABLE_COVERAGE=ON`, excludes `PerformanceEvalTests|AllTests`, and generates `coverage-summary.txt` + `coverage.xml` with `uvx gcovr`.
 - `coverage-ferox`: runs on self-hosted Linux for non-PR events with the same coverage configuration.
 - `pr-test-summary`: runs only on pull requests and posts a consolidated comment with build and coverage job status.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -135,6 +135,13 @@ target_compile_definitions(test_growth_shapes PRIVATE STANDALONE_TEST)
 add_test(NAME GrowthShapeTests COMMAND test_growth_shapes)
 set_tests_properties(GrowthShapeTests PROPERTIES TIMEOUT 300)
 
+# Statistical regression tests for simulation output distributions
+add_executable(test_simulation_stat_regression test_simulation_stat_regression.c)
+target_link_libraries(test_simulation_stat_regression PRIVATE ferox_server_lib)
+target_compile_definitions(test_simulation_stat_regression PRIVATE STANDALONE_TEST)
+add_test(NAME SimulationStatRegressionTests COMMAND test_simulation_stat_regression)
+set_tests_properties(SimulationStatRegressionTests PROPERTIES TIMEOUT 240)
+
 # GUI unit tests (no SDL dependency - tests logic only)
 add_executable(test_gui test_gui.c)
 target_link_libraries(test_gui PRIVATE m)

--- a/tests/test_simulation_stat_regression.c
+++ b/tests/test_simulation_stat_regression.c
@@ -1,0 +1,211 @@
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../src/shared/utils.h"
+#include "../src/server/simulation.h"
+#include "../src/server/world.h"
+
+typedef struct {
+    float occupied_ratio;
+    float active_colonies;
+    float dominant_share;
+} SeedMetrics;
+
+typedef struct {
+    float mean;
+    float stddev;
+    float min;
+    float max;
+} Summary;
+
+typedef struct {
+    const char* name;
+    float expected_mean;
+    float mean_tolerance;
+    float expected_stddev;
+    float stddev_tolerance;
+} MetricThreshold;
+
+static int tests_failed = 0;
+
+#define ASSERT(cond, msg) do { \
+    if (!(cond)) { \
+        printf("FAILED\\n    %s\\n    At %s:%d\\n", msg, __FILE__, __LINE__); \
+        tests_failed++; \
+        return; \
+    } \
+} while (0)
+
+static Summary summarize(const float* values, int count) {
+    Summary s = {0};
+    if (count <= 0) {
+        return s;
+    }
+
+    s.min = values[0];
+    s.max = values[0];
+    double sum = 0.0;
+    for (int i = 0; i < count; i++) {
+        sum += values[i];
+        if (values[i] < s.min) s.min = values[i];
+        if (values[i] > s.max) s.max = values[i];
+    }
+
+    s.mean = (float)(sum / (double)count);
+
+    double sq_sum = 0.0;
+    for (int i = 0; i < count; i++) {
+        double delta = (double)values[i] - (double)s.mean;
+        sq_sum += delta * delta;
+    }
+    s.stddev = (float)sqrt(sq_sum / (double)count);
+    return s;
+}
+
+static int count_grid_cells(const World* world, uint32_t colony_id) {
+    int count = 0;
+    const int cells = world->width * world->height;
+    for (int i = 0; i < cells; i++) {
+        if (world->cells[i].colony_id == colony_id) {
+            count++;
+        }
+    }
+    return count;
+}
+
+static SeedMetrics run_seed(uint32_t seed) {
+    const int width = 96;
+    const int height = 64;
+    const int initial_colonies = 14;
+    const int ticks = 90;
+
+    SeedMetrics m = {0};
+
+    World* world = world_create(width, height);
+    if (!world) {
+        return m;
+    }
+
+    rng_seed(seed);
+    srand(seed);
+    world_init_random_colonies(world, initial_colonies);
+
+    for (int i = 0; i < ticks; i++) {
+        simulation_tick(world);
+    }
+
+    int active_colonies = 0;
+    int total_cells = 0;
+    int largest_colony = 0;
+
+    for (size_t i = 0; i < world->colony_count; i++) {
+        const Colony* c = &world->colonies[i];
+        if (!c->active || c->cell_count == 0) {
+            continue;
+        }
+
+        const int grid_cells = count_grid_cells(world, c->id);
+        if (grid_cells <= 0) {
+            continue;
+        }
+
+        active_colonies++;
+        total_cells += grid_cells;
+        if (grid_cells > largest_colony) {
+            largest_colony = grid_cells;
+        }
+    }
+
+    const int world_cells = width * height;
+    m.occupied_ratio = (world_cells > 0) ? (float)total_cells / (float)world_cells : 0.0f;
+    m.active_colonies = (float)active_colonies;
+    m.dominant_share = (total_cells > 0) ? (float)largest_colony / (float)total_cells : 0.0f;
+
+    world_destroy(world);
+    return m;
+}
+
+static void assert_threshold(const MetricThreshold* threshold, const Summary* summary) {
+    const float mean_delta = fabsf(summary->mean - threshold->expected_mean);
+    const float stddev_delta = fabsf(summary->stddev - threshold->expected_stddev);
+
+    printf("STAT_REGRESSION metric=%s mean=%.6f stddev=%.6f min=%.6f max=%.6f expected_mean=%.6f mean_tol=%.6f expected_stddev=%.6f stddev_tol=%.6f\n",
+           threshold->name,
+           summary->mean,
+           summary->stddev,
+           summary->min,
+           summary->max,
+           threshold->expected_mean,
+           threshold->mean_tolerance,
+           threshold->expected_stddev,
+           threshold->stddev_tolerance);
+
+    ASSERT(mean_delta <= threshold->mean_tolerance, "mean drift exceeded tolerance");
+    ASSERT(stddev_delta <= threshold->stddev_tolerance, "stddev drift exceeded tolerance");
+}
+
+static int run_statistical_regression_test(void) {
+    static const uint32_t seeds[] = {
+        101u, 173u, 251u, 307u, 409u, 523u, 601u, 709u,
+        811u, 907u, 1009u, 1103u, 1201u, 1303u, 1409u, 1511u,
+        1601u, 1709u, 1801u, 1901u, 2003u, 2111u, 2203u, 2309u,
+    };
+
+    const int seed_count = (int)(sizeof(seeds) / sizeof(seeds[0]));
+    float occupied_values[24] = {0};
+    float active_values[24] = {0};
+    float dominant_values[24] = {0};
+
+    for (int i = 0; i < seed_count; i++) {
+        SeedMetrics m = run_seed(seeds[i]);
+        occupied_values[i] = m.occupied_ratio;
+        active_values[i] = m.active_colonies;
+        dominant_values[i] = m.dominant_share;
+    }
+
+    const Summary occupied_summary = summarize(occupied_values, seed_count);
+    const Summary active_summary = summarize(active_values, seed_count);
+    const Summary dominant_summary = summarize(dominant_values, seed_count);
+
+    static const MetricThreshold thresholds[] = {
+        {
+            .name = "occupied_ratio",
+            .expected_mean = 0.9540f,
+            .mean_tolerance = 0.0600f,
+            .expected_stddev = 0.0320f,
+            .stddev_tolerance = 0.0300f,
+        },
+        {
+            .name = "active_colonies",
+            .expected_mean = 21.0000f,
+            .mean_tolerance = 3.0000f,
+            .expected_stddev = 3.4000f,
+            .stddev_tolerance = 1.8000f,
+        },
+        {
+            .name = "dominant_share",
+            .expected_mean = 0.1710f,
+            .mean_tolerance = 0.0500f,
+            .expected_stddev = 0.0380f,
+            .stddev_tolerance = 0.0250f,
+        },
+    };
+
+    assert_threshold(&thresholds[0], &occupied_summary);
+    assert_threshold(&thresholds[1], &active_summary);
+    assert_threshold(&thresholds[2], &dominant_summary);
+
+    return tests_failed;
+}
+
+int main(void) {
+    printf("\n=== Simulation Statistical Regression Tests ===\n");
+    printf("Seeds: 24, ticks per seed: 90, world: 96x64\n");
+    printf("Policy: check distribution mean + stddev for key metrics\n\n");
+
+    int failed = run_statistical_regression_test();
+    printf("\nSimulation Statistical Regression: %s\n", failed == 0 ? "PASSED" : "FAILED");
+    return failed == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary
- add a new `SimulationStatRegressionTests` suite that runs 24 fixed seeds and checks distribution mean/stddev for key simulation metrics (`occupied_ratio`, `active_colonies`, `dominant_share`)
- integrate statistical regression reporting into CI for both macOS and self-hosted Linux build jobs, including parsed metric summaries in the GitHub Actions job summary
- document threshold rationale and anti-flake strategy in `docs/STATISTICAL_REGRESSION.md`, and link it from testing docs

Closes #57.