### PR TITLE
feat(model): add explicit trait cost accounting

### DIFF
--- a/docs/GENETICS.md
+++ b/docs/GENETICS.md
@@ -737,6 +737,18 @@ Probability of **horizontal gene transfer** when adjacent to another colony.
 
 ### Survival Strategy Traits
 
+#### Expensive-Trait Energetic Burden (derived)
+
+The simulator applies explicit cost accounting to four high-impact traits:
+
+`trait_load = toxin_production*0.24 + (biofilm_investment*biofilm_tendency)*0.20 + signal_emission*0.16 + motility*0.18`
+
+- Higher `trait_load` reduces effective spread pressure.
+- Higher `trait_load` increases nutrient maintenance demand and per-tick death pressure.
+- This discourages universal all-max trait profiles and produces stable strategy tradeoffs.
+
+---
+
 #### Dormancy Threshold (float, 0-1)
 
 **Stress level** that triggers transition to dormant state.

--- a/docs/SIMULATION.md
+++ b/docs/SIMULATION.md
@@ -9,6 +9,31 @@ This document explains how the simulation works, including the world grid, tick 
 - **Strategy archetypes**: new genomes are seeded from 8 archetypes in `genome_create_random()` (`BERSERKER`, `TURTLE`, `SWARM`, `TOXIC`, `HIVE`, `NOMAD`, `PARASITE`, `CHAOTIC`), then mutated over time.
 - **Scent/quorum/biofilm/dormancy**: scent and neighbor sampling bias spread direction; quorum activation is derived from `signal_strength` vs `quorum_threshold`; biofilm grows/decays each tick; dormancy is stress-triggered and reduces turnover death while suppressing expansion pressure.
 
+## Expensive-Trait Cost Accounting
+
+To prevent all lineages converging on universal max values, expensive social traits now add an explicit energetic burden that feeds both growth and survival.
+
+### Costed Traits and Weights
+
+| Trait | Symbol | Weight |
+|-------|--------|--------|
+| Toxin secretion | `toxin_production` | `0.24` |
+| EPS/biofilm production | `biofilm_investment * biofilm_tendency` | `0.20` |
+| Signaling output | `signal_emission` | `0.16` |
+| Motility drive | `motility` | `0.18` |
+
+`trait_load = clamp(sum(weighted_traits), 0, 1)`
+
+### How It Affects Dynamics
+
+- **Growth pressure**: spread chance is multiplied by `growth_cost_multiplier = clamp(1 - trait_load, 0.35, 1.0)`.
+- **Survival pressure**: turnover/starvation/toxin death calculations are multiplied by `survival_cost_multiplier = 1 + trait_load * 0.55`.
+- **Resource pressure**: occupied-cell nutrient consumption is scaled by `1 + trait_load * 0.6`.
+
+### Rationale
+
+This keeps high-investment strategies viable in the right contexts, while forcing tradeoffs: lineages that max toxin/EPS/signaling/motility gain tactical advantages but pay ongoing metabolic and mortality costs.
+
 ## World Grid Structure
 
 The simulation takes place on a 2D rectangular grid.

--- a/src/server/atomic_sim.c
+++ b/src/server/atomic_sim.c
@@ -285,6 +285,7 @@ static void atomic_apply_cell_turnover(World* world) {
 
         Colony* colony = world_get_colony(world, cell->colony_id);
         if (!colony || !colony->active) continue;
+        float trait_survival_cost = calculate_survival_cost_multiplier(colony);
 
         float death_chance = 0.0015f;
 
@@ -321,6 +322,8 @@ static void atomic_apply_cell_turnover(World* world) {
         if (cell->age > 140) {
             death_chance += ((float)cell->age - 140.0f) * 0.0008f;
         }
+
+        death_chance *= trait_survival_cost;
 
         death_chance = utils_clamp_f(death_chance, 0.0f, 0.35f);
         if (rand_float() < death_chance) {

--- a/src/server/simulation.c
+++ b/src/server/simulation.c
@@ -7,6 +7,10 @@
 #include <string.h>
 #include <math.h>
 
+float calculate_expensive_trait_load(const Genome* genome);
+float calculate_growth_cost_multiplier(const Colony* colony);
+float calculate_survival_cost_multiplier(const Colony* colony);
+
 #if defined(FEROX_SIMD_AVX2)
 #include <immintrin.h>
 #endif
@@ -668,6 +672,7 @@ void simulation_spread(World* world) {
                     float dormancy_factor = colony->is_dormant
                         ? (0.12f + colony->genome.dormancy_resistance * 0.28f)
                         : 1.0f;
+                    float trait_growth_cost = calculate_growth_cost_multiplier(colony);
                     
                     // Curvature smoothing: prefer filling concavities for smooth edges
                     float curvature = calculate_curvature_boost(world, nx, ny, cell->colony_id);
@@ -687,7 +692,7 @@ void simulation_spread(World* world) {
                     float spread_prob = colony->genome.spread_rate * colony->genome.metabolism * 
                                         env_modifier * dir_weight * scent_modifier * 
                                         strategic_modifier * history_bonus * biomass_pressure *
-                                        quorum_boost * dormancy_factor * curvature *
+                                        quorum_boost * dormancy_factor * trait_growth_cost * curvature *
                                         iso_correction * noise * perception * growth_uptake * 2.0f;
                     
                     if (rand_float() < spread_prob) {
@@ -1153,10 +1158,11 @@ void simulation_spread_region(World* world, int start_x, int start_y,
                     float dormancy_factor = colony->is_dormant
                         ? (0.12f + colony->genome.dormancy_resistance * 0.28f)
                         : 1.0f;
+                    float trait_growth_cost = calculate_growth_cost_multiplier(colony);
                     float growth_uptake = monod_growth_multiplier(world, world->nutrients[y * world->width + x]);
                     float spread_chance = colony->genome.spread_rate * colony->genome.metabolism *
                                           biomass_pressure * quorum_boost * dormancy_factor *
-                                          growth_uptake * 3.2f;
+                                          trait_growth_cost * growth_uptake * 3.2f;
                     if (rand_float() < spread_chance) {
                         pending_buffer_add(pending, nx, ny, cell->colony_id);
                     }
@@ -1333,6 +1339,8 @@ void simulation_update_nutrients(World* world) {
                 consumption *= colony->genome.metabolism;
                 // High efficiency reduces consumption
                 consumption *= (1.0f - colony->genome.efficiency * 0.5f);
+                // Expensive traits increase maintenance demand.
+                consumption *= (1.0f + calculate_expensive_trait_load(&colony->genome) * 0.6f);
                 consumption *= monod_uptake_multiplier(world, nutrients[i]);
             }
             float value = nutrients[i] - consumption;
@@ -1475,6 +1483,7 @@ void simulation_consume_resources(World* world) {
             if (colony && colony->active) {
                 float consumption = colony->genome.resource_consumption * 
                                     (0.5f + colony->genome.aggression * 0.5f);
+                consumption *= (1.0f + calculate_expensive_trait_load(&colony->genome) * 0.6f);
                 consumption *= monod_uptake_multiplier(world, n);
                 n -= consumption * 0.05f;
             }
@@ -1858,12 +1867,14 @@ void simulation_tick(World* world) {
         
         Colony* colony = world_get_colony(world, cell->colony_id);
         if (!colony || !colony->active) continue;
+        float trait_survival_cost = calculate_survival_cost_multiplier(colony);
         
         // STARVATION: Cells in depleted areas may die
         float nutrients = world->nutrients[i];
         if (nutrients < 0.2f) {
             // Low nutrients - chance of cell death based on efficiency
-            float death_chance = (0.2f - nutrients) * 0.1f * (1.0f - colony->genome.efficiency);
+            float death_chance = (0.2f - nutrients) * 0.1f *
+                                 (1.0f - colony->genome.efficiency) * trait_survival_cost;
             if (rand_float() < death_chance) {
                 cell->colony_id = 0;
                 cell->age = 0;
@@ -1877,7 +1888,8 @@ void simulation_tick(World* world) {
         // TOXIN DEATH: Cells in toxic areas may die
         float toxins = world->toxins[i];
         if (toxins > 0.3f) {
-            float death_chance = (toxins - 0.3f) * 0.15f * (1.0f - colony->genome.toxin_resistance);
+            float death_chance = (toxins - 0.3f) * 0.15f *
+                                 (1.0f - colony->genome.toxin_resistance) * trait_survival_cost;
             if (rand_float() < death_chance) {
                 cell->colony_id = 0;
                 cell->age = 0;
@@ -1921,6 +1933,8 @@ void simulation_tick(World* world) {
             float dormancy_protection = 0.5f - colony->genome.dormancy_resistance * 0.35f;
             base_death_rate *= utils_clamp_f(dormancy_protection, 0.12f, 0.5f);
         }
+
+        base_death_rate *= trait_survival_cost;
         
         if (rand_float() < base_death_rate) {
             // NUTRIENT RECYCLING: Dead cells release nutrients back into environment

--- a/src/server/simulation_common.c
+++ b/src/server/simulation_common.c
@@ -196,3 +196,31 @@ int count_enemy_neighbors(World* world, int x, int y, uint32_t colony_id) {
     }
     return count;
 }
+
+float calculate_expensive_trait_load(const Genome* genome) {
+    if (!genome) return 0.0f;
+
+    // Energetic burden from expensive social traits.
+    // Weights are calibrated so all-max does not collapse the simulation,
+    // but is still clearly penalized versus balanced configurations.
+    const float toxin_cost = genome->toxin_production * 0.24f;
+    const float biofilm_cost = (genome->biofilm_investment * genome->biofilm_tendency) * 0.20f;
+    const float signaling_cost = genome->signal_emission * 0.16f;
+    const float motility_cost = genome->motility * 0.18f;
+
+    return utils_clamp_f(toxin_cost + biofilm_cost + signaling_cost + motility_cost, 0.0f, 1.0f);
+}
+
+float calculate_growth_cost_multiplier(const Colony* colony) {
+    if (!colony) return 1.0f;
+
+    float load = calculate_expensive_trait_load(&colony->genome);
+    return utils_clamp_f(1.0f - load, 0.35f, 1.0f);
+}
+
+float calculate_survival_cost_multiplier(const Colony* colony) {
+    if (!colony) return 1.0f;
+
+    float load = calculate_expensive_trait_load(&colony->genome);
+    return 1.0f + load * 0.55f;
+}

--- a/src/server/simulation_common.h
+++ b/src/server/simulation_common.h
@@ -23,4 +23,9 @@ float get_scent_influence(World* world, int x, int y, int dx, int dy, uint32_t c
 int count_friendly_neighbors(World* world, int x, int y, uint32_t colony_id);
 int count_enemy_neighbors(World* world, int x, int y, uint32_t colony_id);
 
+// Expensive-trait energetic burden used by growth/survival accounting.
+float calculate_expensive_trait_load(const Genome* genome);
+float calculate_growth_cost_multiplier(const Colony* colony);
+float calculate_survival_cost_multiplier(const Colony* colony);
+
 #endif

--- a/tests/test_simulation_common.c
+++ b/tests/test_simulation_common.c
@@ -143,6 +143,77 @@ TEST(get_quorum_activation_handles_null_below_and_above_threshold) {
     ASSERT(get_quorum_activation(&colony) > 0.6f, "activation increases above threshold");
 }
 
+TEST(expensive_trait_load_reflects_configured_weights) {
+    Genome g;
+    memset(&g, 0, sizeof(Genome));
+
+    g.toxin_production = 1.0f;
+    g.biofilm_investment = 1.0f;
+    g.biofilm_tendency = 1.0f;
+    g.signal_emission = 1.0f;
+    g.motility = 1.0f;
+
+    float load = calculate_expensive_trait_load(&g);
+    ASSERT_NEAR(load, 0.78f, 0.0001f);
+}
+
+TEST(growth_and_survival_costs_create_tradeoff_for_max_traits) {
+    Colony balanced = make_colony(30);
+    balanced.genome.toxin_production = 0.3f;
+    balanced.genome.biofilm_investment = 0.3f;
+    balanced.genome.biofilm_tendency = 0.6f;
+    balanced.genome.signal_emission = 0.3f;
+    balanced.genome.motility = 0.3f;
+
+    Colony maxed = make_colony(31);
+    maxed.genome.toxin_production = 1.0f;
+    maxed.genome.biofilm_investment = 1.0f;
+    maxed.genome.biofilm_tendency = 1.0f;
+    maxed.genome.signal_emission = 1.0f;
+    maxed.genome.motility = 1.0f;
+
+    float balanced_growth = calculate_growth_cost_multiplier(&balanced);
+    float max_growth = calculate_growth_cost_multiplier(&maxed);
+    ASSERT(max_growth < balanced_growth, "max expensive traits should reduce growth multiplier");
+
+    float balanced_survival = calculate_survival_cost_multiplier(&balanced);
+    float max_survival = calculate_survival_cost_multiplier(&maxed);
+    ASSERT(max_survival > balanced_survival, "max expensive traits should increase survival burden");
+}
+
+TEST(baseline_sweep_avoids_universal_max_trait_dominance) {
+    const float levels[] = {0.0f, 0.5f, 1.0f};
+    float best_score = -1.0f;
+    bool best_all_max = false;
+
+    for (int ti = 0; ti < 3; ti++) {
+        for (int bi = 0; bi < 3; bi++) {
+            for (int si = 0; si < 3; si++) {
+                for (int mi = 0; mi < 3; mi++) {
+                    Colony colony = make_colony(40);
+                    colony.genome.toxin_production = levels[ti];
+                    colony.genome.biofilm_investment = levels[bi];
+                    colony.genome.biofilm_tendency = levels[bi];
+                    colony.genome.signal_emission = levels[si];
+                    colony.genome.motility = levels[mi];
+
+                    float growth = calculate_growth_cost_multiplier(&colony);
+                    float survival = calculate_survival_cost_multiplier(&colony);
+                    float score = growth / survival;
+
+                    if (score > best_score) {
+                        best_score = score;
+                        best_all_max = (levels[ti] == 1.0f && levels[bi] == 1.0f &&
+                                        levels[si] == 1.0f && levels[mi] == 1.0f);
+                    }
+                }
+            }
+        }
+    }
+
+    ASSERT(!best_all_max, "all-max expensive trait profile should not dominate baseline sweep");
+}
+
 TEST(get_direction_weight_maps_all_cardinals_and_default) {
     Genome g;
     memset(&g, 0, sizeof(Genome));
@@ -275,6 +346,9 @@ int run_simulation_common_tests(void) {
     RUN_TEST(calculate_biomass_pressure_handles_isolated_world);
     RUN_TEST(calculate_biomass_pressure_scales_with_friendly_neighbors);
     RUN_TEST(get_quorum_activation_handles_null_below_and_above_threshold);
+    RUN_TEST(expensive_trait_load_reflects_configured_weights);
+    RUN_TEST(growth_and_survival_costs_create_tradeoff_for_max_traits);
+    RUN_TEST(baseline_sweep_avoids_universal_max_trait_dominance);
     RUN_TEST(get_direction_weight_maps_all_cardinals_and_default);
     RUN_TEST(calculate_curvature_boost_reflects_neighbor_count);
     RUN_TEST(calculate_perception_modifier_handles_range_and_threat_branches);


### PR DESCRIPTION
## Summary
- add explicit energetic burden accounting for expensive social traits (`toxin_production`, EPS/biofilm investment, `signal_emission`, `motility`) with shared helper functions
- apply the burden to growth pressure (spread probability), survival pressure (death probability), and maintenance demand (nutrient consumption) in both simulation engines
- add baseline sweep/tradeoff tests and document the new model parameters and rationale

## Testing
- `ctest --test-dir build --output-on-failure -R SimulationCommonTests`
- `ctest --test-dir build --output-on-failure -R SimulationLogicTests`

Closes #55