### PR TITLE
model: formalize reaction-diffusion solver controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ make install
 
 ```bash
 ./ferox_server -p 8080 -w 200 -H 100 -c 20 -t 4 -r 50
+  --nutrient-diffusion 0.00 --nutrient-decay 0.00 \
+  --toxin-diffusion 0.00 --toxin-decay 0.05 \
+  --signal-diffusion 0.075 --signal-decay 0.10
 ```
 
 | Option | Description |
@@ -147,6 +150,14 @@ make install
 | `-c, --colonies` | Initial colony count |
 | `-t, --threads` | Thread pool size |
 | `-r, --rate` | Tick rate in ms (default: 50 from `main.c`) |
+| `--nutrient-diffusion` | Nutrient diffusion coefficient (0.0-0.25) |
+| `--nutrient-decay` | Nutrient decay coefficient (0.0-1.0) |
+| `--toxin-diffusion` | Toxin diffusion coefficient (0.0-0.25) |
+| `--toxin-decay` | Toxin decay coefficient (0.0-1.0) |
+| `--signal-diffusion` | Signal diffusion coefficient (0.0-0.25) |
+| `--signal-decay` | Signal decay coefficient (0.0-1.0) |
+
+Stability guardrail: each field must satisfy `4 * diffusion + decay <= 1.0`.
 
 **Starting Clients:**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -127,6 +127,14 @@ Server binary defaults shown (scripts/run.sh may use different defaults):
 | `-c, --colonies` | 5 | Initial colony count |
 | `-t, --threads` | 4 | Thread pool size |
 | `-r, --rate` | 100 | Milliseconds per tick |
+| `--nutrient-diffusion` | 0.00 | Nutrient diffusion coefficient (`0.0-0.25`) |
+| `--nutrient-decay` | 0.00 | Nutrient decay coefficient (`0.0-1.0`) |
+| `--toxin-diffusion` | 0.00 | Toxin diffusion coefficient (`0.0-0.25`) |
+| `--toxin-decay` | 0.05 | Toxin decay coefficient (`0.0-1.0`) |
+| `--signal-diffusion` | 0.075 | Signal diffusion coefficient (`0.0-0.25`) |
+| `--signal-decay` | 0.10 | Signal decay coefficient (`0.0-1.0`) |
+
+Solver stability guardrail per field: `4 * diffusion + decay <= 1.0`.
 
 ### Client Options
 

--- a/docs/SIMULATION.md
+++ b/docs/SIMULATION.md
@@ -900,6 +900,7 @@ float* nutrients;  // Per-cell nutrient concentration (0-1)
 - Nutrients regenerate slowly over time
 - Consumed by colony growth
 - Colonies with high `nutrient_sensitivity` spread toward nutrient-rich areas
+- Optional reaction-diffusion controls: `--nutrient-diffusion`, `--nutrient-decay`
 
 #### Optional Monod Growth/Uptake Coupling
 
@@ -947,6 +948,7 @@ float* toxins;  // Per-cell toxin concentration (0-1)
 - Diffuses to neighboring cells
 - Decays over time
 - Damages colonies based on (1 - toxin_resistance)
+- Configurable controls: `--toxin-diffusion`, `--toxin-decay`
 
 ### Signal Layer
 
@@ -960,11 +962,22 @@ uint32_t* signal_source;  // Colony ID that emitted signal
 - Diffuses rapidly
 - Decays quickly
 - Colonies respond based on `signal_sensitivity`
+- Configurable controls: `--signal-diffusion`, `--signal-decay`
 
 **Signal Uses:**
 - Coordinate movement toward kin
 - Mark territory
 - Warn of dangers
+
+### Reaction-Diffusion Guardrails
+
+Each environmental field (`nutrients`, `toxins`, `signals`) uses an explicit 4-neighbor update with independent diffusion/decay coefficients. To avoid unstable updates, Ferox rejects parameters unless:
+
+`4 * diffusion + decay <= 1.0`
+
+Additional bounds:
+- `diffusion` in `[0.0, 0.25]`
+- `decay` in `[0.0, 1.0]`
 
 ## Border Detection
 

--- a/src/server/main.c
+++ b/src/server/main.c
@@ -40,6 +40,12 @@ static void print_usage(const char* program) {
     printf("  -t, --threads <count>    Thread pool size (default: 4)\n");
     printf("  -c, --colonies <count>   Initial colony count (default: 5)\n");
     printf("  -r, --rate <ms>          Tick rate in milliseconds (default: 100)\n");
+    printf("      --nutrient-diffusion <v>  Nutrient diffusion [0.0, 0.25] (default: %.3f)\n", RD_DEFAULT_NUTRIENT_DIFFUSION);
+    printf("      --nutrient-decay <v>      Nutrient decay [0.0, 1.0] (default: %.3f)\n", RD_DEFAULT_NUTRIENT_DECAY);
+    printf("      --toxin-diffusion <v>     Toxin diffusion [0.0, 0.25] (default: %.3f)\n", RD_DEFAULT_TOXIN_DIFFUSION);
+    printf("      --toxin-decay <v>         Toxin decay [0.0, 1.0] (default: %.3f)\n", RD_DEFAULT_TOXIN_DECAY);
+    printf("      --signal-diffusion <v>    Signal diffusion [0.0, 0.25] (default: %.3f)\n", RD_DEFAULT_SIGNAL_DIFFUSION);
+    printf("      --signal-decay <v>        Signal decay [0.0, 1.0] (default: %.3f)\n", RD_DEFAULT_SIGNAL_DECAY);
     printf("  -h, --help               Show this help message\n");
 }
 
@@ -69,6 +75,23 @@ static bool parse_port_arg(const char* arg, uint16_t* out_port) {
     return true;
 }
 
+static bool parse_float_arg(const char* arg, float min_value, float max_value, float* out_value) {
+    if (!arg || !out_value) return false;
+
+    errno = 0;
+    char* end = NULL;
+    float parsed = strtof(arg, &end);
+    if (errno != 0 || end == arg || *end != '\0') {
+        return false;
+    }
+    if (parsed < min_value || parsed > max_value) {
+        return false;
+    }
+
+    *out_value = parsed;
+    return true;
+}
+
 int main(int argc, char* argv[]) {
     // Default configuration
     uint16_t port = 8080;
@@ -77,6 +100,12 @@ int main(int argc, char* argv[]) {
     int thread_count = 4;
     int initial_colonies = 20;
     int tick_rate_ms = 50;  // Faster default (was 100ms)
+
+    RDSolverControls rd_controls = {
+        .nutrients = {RD_DEFAULT_NUTRIENT_DIFFUSION, RD_DEFAULT_NUTRIENT_DECAY},
+        .toxins = {RD_DEFAULT_TOXIN_DIFFUSION, RD_DEFAULT_TOXIN_DECAY},
+        .signals = {RD_DEFAULT_SIGNAL_DIFFUSION, RD_DEFAULT_SIGNAL_DECAY},
+    };
     
     // Long options
     static struct option long_options[] = {
@@ -86,6 +115,12 @@ int main(int argc, char* argv[]) {
         {"threads",  required_argument, 0, 't'},
         {"colonies", required_argument, 0, 'c'},
         {"rate",     required_argument, 0, 'r'},
+        {"nutrient-diffusion", required_argument, 0, 1000},
+        {"nutrient-decay", required_argument, 0, 1001},
+        {"toxin-diffusion", required_argument, 0, 1002},
+        {"toxin-decay", required_argument, 0, 1003},
+        {"signal-diffusion", required_argument, 0, 1004},
+        {"signal-decay", required_argument, 0, 1005},
         {"help",     no_argument,       0, 'h'},
         {0, 0, 0, 0}
     };
@@ -131,6 +166,42 @@ int main(int argc, char* argv[]) {
                     return 1;
                 }
                 break;
+            case 1000:
+                if (!parse_float_arg(optarg, 0.0f, RD_FIELD_MAX_DIFFUSION, &rd_controls.nutrients.diffusion)) {
+                    fprintf(stderr, "Error: Invalid nutrient diffusion '%s'\n", optarg);
+                    return 1;
+                }
+                break;
+            case 1001:
+                if (!parse_float_arg(optarg, 0.0f, 1.0f, &rd_controls.nutrients.decay)) {
+                    fprintf(stderr, "Error: Invalid nutrient decay '%s'\n", optarg);
+                    return 1;
+                }
+                break;
+            case 1002:
+                if (!parse_float_arg(optarg, 0.0f, RD_FIELD_MAX_DIFFUSION, &rd_controls.toxins.diffusion)) {
+                    fprintf(stderr, "Error: Invalid toxin diffusion '%s'\n", optarg);
+                    return 1;
+                }
+                break;
+            case 1003:
+                if (!parse_float_arg(optarg, 0.0f, 1.0f, &rd_controls.toxins.decay)) {
+                    fprintf(stderr, "Error: Invalid toxin decay '%s'\n", optarg);
+                    return 1;
+                }
+                break;
+            case 1004:
+                if (!parse_float_arg(optarg, 0.0f, RD_FIELD_MAX_DIFFUSION, &rd_controls.signals.diffusion)) {
+                    fprintf(stderr, "Error: Invalid signal diffusion '%s'\n", optarg);
+                    return 1;
+                }
+                break;
+            case 1005:
+                if (!parse_float_arg(optarg, 0.0f, 1.0f, &rd_controls.signals.decay)) {
+                    fprintf(stderr, "Error: Invalid signal decay '%s'\n", optarg);
+                    return 1;
+                }
+                break;
             case 'h':
                 print_usage(argv[0]);
                 return 0;
@@ -148,6 +219,9 @@ int main(int argc, char* argv[]) {
     printf("Thread count:    %d\n", thread_count);
     printf("Initial colonies: %d\n", initial_colonies);
     printf("Tick rate:       %d ms\n", tick_rate_ms);
+    printf("RD nutrients:    diffusion=%.3f decay=%.3f\n", rd_controls.nutrients.diffusion, rd_controls.nutrients.decay);
+    printf("RD toxins:       diffusion=%.3f decay=%.3f\n", rd_controls.toxins.diffusion, rd_controls.toxins.decay);
+    printf("RD signals:      diffusion=%.3f decay=%.3f\n", rd_controls.signals.diffusion, rd_controls.signals.decay);
     printf("\n");
     
     // Create server
@@ -155,6 +229,13 @@ int main(int argc, char* argv[]) {
     Server* server = server_create(port, world_width, world_height, thread_count);
     if (!server) {
         fprintf(stderr, "Error: Failed to create server\n");
+        return 1;
+    }
+
+    char rd_error[256];
+    if (!world_set_rd_controls(server->world, &rd_controls, rd_error, sizeof(rd_error))) {
+        fprintf(stderr, "Error: Invalid reaction-diffusion controls: %s\n", rd_error[0] ? rd_error : "validation failed");
+        server_destroy(server);
         return 1;
     }
     

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -285,6 +285,14 @@ static bool server_rebuild_world_state(Server* server, int width, int height, in
         return false;
     }
 
+    if (server->world) {
+        RDSolverControls controls = world_get_rd_controls(server->world);
+        if (!world_set_rd_controls(new_world, &controls, NULL, 0)) {
+            world_destroy(new_world);
+            return false;
+        }
+    }
+
     if (initial_colonies > 0) {
         world_init_random_colonies(new_world, initial_colonies);
     }

--- a/src/server/simulation.c
+++ b/src/server/simulation.c
@@ -40,7 +40,6 @@ static const float DIR8_WEIGHT[] = {1.0f, 0.7071f, 1.0f, 0.7071f, 1.0f, 0.7071f,
 // Environmental constants
 #define NUTRIENT_DEPLETION_RATE 0.05f   // Nutrients consumed per cell per tick
 #define NUTRIENT_REGEN_RATE 0.002f      // Natural nutrient regeneration
-#define TOXIN_DECAY_RATE 0.01f          // Toxin decay per tick
 #define QUORUM_SENSING_RADIUS 3         // Radius for local density calculation
 
 static inline float monod_saturation(float substrate, float half_saturation) {
@@ -91,24 +90,6 @@ static void simd_mul_inplace_avx2(float* values, int count, float factor) {
 }
 
 __attribute__((target("avx2")))
-static void simd_sub_clamp01_inplace_avx2(float* values, int count, float sub) {
-    const __m256 vsub = _mm256_set1_ps(sub);
-    const __m256 vzero = _mm256_set1_ps(0.0f);
-    const __m256 vone = _mm256_set1_ps(1.0f);
-    int i = 0;
-    for (; i + 8 <= count; i += 8) {
-        __m256 v = _mm256_loadu_ps(values + i);
-        v = _mm256_sub_ps(v, vsub);
-        v = _mm256_max_ps(v, vzero);
-        v = _mm256_min_ps(v, vone);
-        _mm256_storeu_ps(values + i, v);
-    }
-    for (; i < count; i++) {
-        values[i] = utils_clamp_f(values[i] - sub, 0.0f, 1.0f);
-    }
-}
-
-__attribute__((target("avx2")))
 static void simd_clamp01_copy_avx2(float* dst, const float* src, int count) {
     const __m256 vzero = _mm256_set1_ps(0.0f);
     const __m256 vone = _mm256_set1_ps(1.0f);
@@ -150,35 +131,6 @@ static void simd_mul_inplace(float* values, int count, float factor) {
     }
 }
 
-static void simd_sub_clamp01_inplace(float* values, int count, float sub) {
-#if defined(FEROX_SIMD_AVX2) && (defined(__x86_64__) || defined(__i386__))
-    if (simd_avx2_runtime_available()) {
-        simd_sub_clamp01_inplace_avx2(values, count, sub);
-        return;
-    }
-#elif defined(FEROX_SIMD_NEON)
-    const float32x4_t vsub = vdupq_n_f32(sub);
-    const float32x4_t vzero = vdupq_n_f32(0.0f);
-    const float32x4_t vone = vdupq_n_f32(1.0f);
-    int i = 0;
-    for (; i + 4 <= count; i += 4) {
-        float32x4_t v = vld1q_f32(values + i);
-        v = vsubq_f32(v, vsub);
-        v = vmaxq_f32(v, vzero);
-        v = vminq_f32(v, vone);
-        vst1q_f32(values + i, v);
-    }
-    for (; i < count; i++) {
-        values[i] = utils_clamp_f(values[i] - sub, 0.0f, 1.0f);
-    }
-    return;
-#endif
-
-    for (int i = 0; i < count; i++) {
-        values[i] = utils_clamp_f(values[i] - sub, 0.0f, 1.0f);
-    }
-}
-
 static void simd_clamp01_copy(float* dst, const float* src, int count) {
 #if defined(FEROX_SIMD_AVX2) && (defined(__x86_64__) || defined(__i386__))
     if (simd_avx2_runtime_available()) {
@@ -203,6 +155,58 @@ static void simd_clamp01_copy(float* dst, const float* src, int count) {
 
     for (int i = 0; i < count; i++) {
         dst[i] = utils_clamp_f(src[i], 0.0f, 1.0f);
+    }
+}
+
+static void apply_diffusion_decay(World* world, float* layer, const RDFieldControl* control, bool clamp01) {
+    if (!world || !layer || !control || !world->scratch_signals) {
+        return;
+    }
+
+    const int width = world->width;
+    const int height = world->height;
+    const int total = width * height;
+    const float diffusion = control->diffusion;
+    const float decay = control->decay;
+
+    if (decay > 0.0f && diffusion == 0.0f) {
+        simd_mul_inplace(layer, total, 1.0f - decay);
+        if (clamp01) {
+            simd_clamp01_copy(layer, layer, total);
+        }
+        return;
+    }
+
+    if (decay == 0.0f && diffusion == 0.0f) {
+        if (clamp01) {
+            simd_clamp01_copy(layer, layer, total);
+        }
+        return;
+    }
+
+    float* scratch = world->scratch_signals;
+    memset(scratch, 0, (size_t)total * sizeof(float));
+
+    const float center = 1.0f - decay - 4.0f * diffusion;
+    for (int y = 0; y < height; y++) {
+        int row = y * width;
+        for (int x = 0; x < width; x++) {
+            int idx = row + x;
+            float next = layer[idx] * center;
+
+            if (y > 0) next += layer[idx - width] * diffusion;
+            if (x + 1 < width) next += layer[idx + 1] * diffusion;
+            if (y + 1 < height) next += layer[idx + width] * diffusion;
+            if (x > 0) next += layer[idx - 1] * diffusion;
+
+            scratch[idx] = next;
+        }
+    }
+
+    if (clamp01) {
+        simd_clamp01_copy(layer, scratch, total);
+    } else {
+        memcpy(layer, scratch, (size_t)total * sizeof(float));
     }
 }
 
@@ -1355,14 +1359,15 @@ void simulation_update_nutrients(World* world) {
             nutrients[i] = value;
         }
     }
+
+    apply_diffusion_decay(world, world->nutrients, &world->rd_controls.nutrients, true);
 }
 
 // Decay toxins over time
 void simulation_decay_toxins(World* world) {
     if (!world || !world->toxins) return;
-    
-    int total_cells = world->width * world->height;
-    simd_sub_clamp01_inplace(world->toxins, total_cells, TOXIN_DECAY_RATE);
+
+    apply_diffusion_decay(world, world->toxins, &world->rd_controls.toxins, true);
 }
 
 // ============================================================================
@@ -1372,10 +1377,9 @@ void simulation_decay_toxins(World* world) {
 // Produce toxins around colony borders
 void simulation_produce_toxins(World* world) {
     if (!world || !world->toxins) return;
-    
-    // Decay existing toxins
-    int total_cells = world->width * world->height;
-    simd_mul_inplace(world->toxins, total_cells, 0.95f);  // 5% decay per tick
+
+    // Decay/diffuse existing toxins before new emissions.
+    simulation_decay_toxins(world);
     
     // Each border cell produces toxins
     for (int y = 0; y < world->height; y++) {
@@ -1500,8 +1504,7 @@ void simulation_consume_resources(World* world) {
         world->nutrients[i] = n;
     }
     
-    // Toxin decay (already SIMD-optimized via sub_clamp01)
-    simd_sub_clamp01_inplace(world->toxins, total, 0.01f);
+    simulation_decay_toxins(world);
 }
 
 // ============================================================================
@@ -1546,7 +1549,11 @@ void simulation_update_scents(World* world) {
             new_sources[idx] = cell->colony_id;
     }
     
-    // Step 2: Diffuse existing scent to neighbors (blur effect)
+    const float signal_diffusion = world->rd_controls.signals.diffusion;
+    const float signal_decay = world->rd_controls.signals.decay;
+    const float signal_center = 1.0f - signal_decay - 4.0f * signal_diffusion;
+
+    // Step 2: Diffuse and decay existing scent
     for (int y = 0; y < height; y++) {
         int row = y * width;
         for (int x = 0; x < width; x++) {
@@ -1556,9 +1563,8 @@ void simulation_update_scents(World* world) {
             
             uint32_t source = signal_source[idx];
             
-            // Diffuse 30% to neighbors, keep 60%, lose 10%
-            float keep = current * 0.6f;
-            float spread = current * 0.075f;  // 30% / 4 directions
+            float keep = current * signal_center;
+            float spread = current * signal_diffusion;
             
             new_signals[idx] += keep;
             if (new_signals[idx] > 0 && source > 0) {
@@ -1651,10 +1657,9 @@ void simulation_resolve_combat(World* world) {
     const int height = world->height;
     Cell* cells = world->cells;
     
-    // Decay existing toxins
+    // Decay/diffuse existing toxins.
     if (world->toxins) {
-        int total = width * height;
-        simd_mul_inplace(world->toxins, total, 0.95f);  // 5% decay per tick
+        simulation_decay_toxins(world);
     }
     
     typedef struct { int x, y; uint32_t winner; uint32_t loser; float strength; } CombatResult;

--- a/src/server/world.c
+++ b/src/server/world.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <stdatomic.h>
 #include <limits.h>
+#include <stdio.h>
 
 #define INITIAL_COLONY_CAPACITY 16
 #define INITIAL_LOOKUP_CAPACITY 32
@@ -16,6 +17,60 @@
 #define MONOD_DEFAULT_UPTAKE_MIN 0.25f
 #define MONOD_DEFAULT_UPTAKE_MAX 1.0f
 #define MONOD_DEFAULT_GROWTH_COUPLING 0.0f
+
+static RDSolverControls world_default_rd_controls(void) {
+    RDSolverControls controls;
+    controls.nutrients.diffusion = RD_DEFAULT_NUTRIENT_DIFFUSION;
+    controls.nutrients.decay = RD_DEFAULT_NUTRIENT_DECAY;
+    controls.toxins.diffusion = RD_DEFAULT_TOXIN_DIFFUSION;
+    controls.toxins.decay = RD_DEFAULT_TOXIN_DECAY;
+    controls.signals.diffusion = RD_DEFAULT_SIGNAL_DIFFUSION;
+    controls.signals.decay = RD_DEFAULT_SIGNAL_DECAY;
+    return controls;
+}
+
+static bool world_validate_rd_field(const RDFieldControl* field,
+                                    const char* field_name,
+                                    char* err_buf,
+                                    size_t err_buf_size) {
+    if (!field || !field_name) {
+        return false;
+    }
+
+    const float diffusion = field->diffusion;
+    const float decay = field->decay;
+
+    if (diffusion < 0.0f || diffusion > RD_FIELD_MAX_DIFFUSION) {
+        if (err_buf && err_buf_size > 0) {
+            snprintf(err_buf, err_buf_size,
+                     "%s diffusion %.4f must be in [0.0, %.2f]",
+                     field_name, diffusion, RD_FIELD_MAX_DIFFUSION);
+        }
+        return false;
+    }
+
+    if (decay < 0.0f || decay > 1.0f) {
+        if (err_buf && err_buf_size > 0) {
+            snprintf(err_buf, err_buf_size,
+                     "%s decay %.4f must be in [0.0, 1.0]",
+                     field_name, decay);
+        }
+        return false;
+    }
+
+    // Explicit 2D/4-neighbor solver guardrail (dt = 1):
+    // center weight = 1 - decay - 4*diffusion must remain non-negative.
+    if ((4.0f * diffusion + decay) > 1.0f) {
+        if (err_buf && err_buf_size > 0) {
+            snprintf(err_buf, err_buf_size,
+                     "%s unstable: 4*diffusion + decay = %.4f exceeds 1.0",
+                     field_name, 4.0f * diffusion + decay);
+        }
+        return false;
+    }
+
+    return true;
+}
 
 World* world_create(int width, int height) {
     if (width <= 0 || height <= 0) {
@@ -44,12 +99,12 @@ World* world_create(int width, int height) {
     world->colony_count = 0;
     world->colony_capacity = INITIAL_COLONY_CAPACITY;
     atomic_init(&world->next_colony_id, 1);
-
     world->monod.enabled = MONOD_DEFAULT_ENABLED;
     world->monod.half_saturation = MONOD_DEFAULT_HALF_SATURATION;
     world->monod.uptake_min = MONOD_DEFAULT_UPTAKE_MIN;
     world->monod.uptake_max = MONOD_DEFAULT_UPTAKE_MAX;
     world->monod.growth_coupling = MONOD_DEFAULT_GROWTH_COUPLING;
+    world->rd_controls = world_default_rd_controls();
     
     // Allocate cells as flat array
     world->cells = (Cell*)calloc(grid_size, sizeof(Cell));
@@ -431,4 +486,27 @@ void world_remove_colony(World* world, uint32_t id) {
             }
         }
     }
+}
+
+bool world_set_rd_controls(World* world, const RDSolverControls* controls,
+                           char* err_buf, size_t err_buf_size) {
+    if (!world || !controls) {
+        return false;
+    }
+
+    if (!world_validate_rd_field(&controls->nutrients, "nutrients", err_buf, err_buf_size) ||
+        !world_validate_rd_field(&controls->toxins, "toxins", err_buf, err_buf_size) ||
+        !world_validate_rd_field(&controls->signals, "signals", err_buf, err_buf_size)) {
+        return false;
+    }
+
+    world->rd_controls = *controls;
+    return true;
+}
+
+RDSolverControls world_get_rd_controls(const World* world) {
+    if (!world) {
+        return world_default_rd_controls();
+    }
+    return world->rd_controls;
 }

--- a/src/server/world.h
+++ b/src/server/world.h
@@ -11,6 +11,15 @@ typedef struct {
     float growth_coupling;
 } MonodKineticsConfig;
 
+#define RD_FIELD_MAX_DIFFUSION 0.25f
+
+#define RD_DEFAULT_NUTRIENT_DIFFUSION 0.00f
+#define RD_DEFAULT_NUTRIENT_DECAY 0.00f
+#define RD_DEFAULT_TOXIN_DIFFUSION 0.00f
+#define RD_DEFAULT_TOXIN_DECAY 0.05f
+#define RD_DEFAULT_SIGNAL_DIFFUSION 0.075f
+#define RD_DEFAULT_SIGNAL_DECAY 0.10f
+
 // Create a new world with given dimensions
 World* world_create(int width, int height);
 
@@ -41,5 +50,12 @@ MonodKineticsConfig world_get_monod_kinetics(const World* world);
 // Track cell addition for O(active_cells) removal and centroid
 void world_colony_add_cell(World* world, uint32_t colony_id, uint32_t cell_idx);
 void world_colony_remove_cell(World* world, uint32_t colony_id, uint32_t cell_idx);
+
+// Validate and apply reaction-diffusion controls.
+bool world_set_rd_controls(World* world, const RDSolverControls* controls,
+                           char* err_buf, size_t err_buf_size);
+
+// Copy current solver controls.
+RDSolverControls world_get_rd_controls(const World* world);
 
 #endif // FEROX_WORLD_H

--- a/src/shared/types.h
+++ b/src/shared/types.h
@@ -168,6 +168,17 @@ typedef struct {
 } Colony;
 
 typedef struct {
+    float diffusion;
+    float decay;
+} RDFieldControl;
+
+typedef struct {
+    RDFieldControl nutrients;
+    RDFieldControl toxins;
+    RDFieldControl signals;
+} RDSolverControls;
+
+typedef struct {
     int width;
     int height;
     Cell* cells;
@@ -197,6 +208,8 @@ typedef struct {
         float uptake_max;
         float growth_coupling;
     } monod;
+
+    RDSolverControls rd_controls;
 } World;
 
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -114,6 +114,12 @@ target_compile_definitions(test_simd_eval PRIVATE STANDALONE_TEST)
 add_test(NAME SimdEvalTests COMMAND test_simd_eval)
 set_tests_properties(SimdEvalTests PROPERTIES TIMEOUT 120)
 
+# Reaction-diffusion solver controls tests
+add_executable(test_rd_controls test_rd_controls.c)
+target_link_libraries(test_rd_controls PRIVATE ferox_server_lib)
+target_compile_definitions(test_rd_controls PRIVATE STANDALONE_TEST)
+add_test(NAME RdControlsTests COMMAND test_rd_controls)
+
 # Broad performance evaluation tests
 add_executable(test_performance_eval test_performance_eval.c)
 target_link_libraries(test_performance_eval PRIVATE ferox_server_lib)

--- a/tests/test_rd_controls.c
+++ b/tests/test_rd_controls.c
@@ -1,0 +1,115 @@
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+
+#include "../src/server/world.h"
+#include "../src/server/simulation.h"
+
+extern void simulation_decay_toxins(World* world);
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name) static void test_##name(void)
+#define RUN_TEST(name) do { \
+    printf("  Running %s... ", #name); \
+    fflush(stdout); \
+    test_##name(); \
+    printf("PASSED\n"); \
+    tests_passed++; \
+} while (0)
+
+#define ASSERT(cond, msg) do { \
+    if (!(cond)) { \
+        printf("FAILED\\n    %s\\n    At %s:%d\\n", msg, __FILE__, __LINE__); \
+        tests_failed++; \
+        return; \
+    } \
+} while (0)
+
+#define ASSERT_NEAR(a, b, eps) ASSERT(fabsf((a) - (b)) <= (eps), #a " ~= " #b)
+
+TEST(custom_toxin_decay_uses_configured_coefficient) {
+    World* world = world_create(4, 1);
+    ASSERT(world != NULL, "world create");
+
+    RDSolverControls controls = world_get_rd_controls(world);
+    controls.toxins.diffusion = 0.0f;
+    controls.toxins.decay = 0.25f;
+    ASSERT(world_set_rd_controls(world, &controls, NULL, 0), "set controls");
+
+    world->toxins[0] = 1.0f;
+    world->toxins[1] = 0.6f;
+    world->toxins[2] = 0.2f;
+    world->toxins[3] = 0.0f;
+
+    simulation_decay_toxins(world);
+
+    ASSERT_NEAR(world->toxins[0], 0.75f, 1e-6f);
+    ASSERT_NEAR(world->toxins[1], 0.45f, 1e-6f);
+    ASSERT_NEAR(world->toxins[2], 0.15f, 1e-6f);
+    ASSERT_NEAR(world->toxins[3], 0.0f, 1e-6f);
+
+    world_destroy(world);
+}
+
+TEST(signal_diffusion_decay_matches_reference_stencil) {
+    World* world = world_create(3, 3);
+    ASSERT(world != NULL, "world create");
+
+    RDSolverControls controls = world_get_rd_controls(world);
+    controls.signals.diffusion = 0.1f;
+    controls.signals.decay = 0.2f;
+    ASSERT(world_set_rd_controls(world, &controls, NULL, 0), "set controls");
+
+    memset(world->signals, 0, (size_t)(world->width * world->height) * sizeof(float));
+    world->signals[4] = 1.0f;  // center pulse
+
+    simulation_update_scents(world);
+
+    ASSERT_NEAR(world->signals[4], 0.4f, 1e-6f);
+    ASSERT_NEAR(world->signals[1], 0.1f, 1e-6f);
+    ASSERT_NEAR(world->signals[3], 0.1f, 1e-6f);
+    ASSERT_NEAR(world->signals[5], 0.1f, 1e-6f);
+    ASSERT_NEAR(world->signals[7], 0.1f, 1e-6f);
+
+    world_destroy(world);
+}
+
+TEST(unstable_solver_controls_are_rejected) {
+    World* world = world_create(8, 8);
+    ASSERT(world != NULL, "world create");
+
+    RDSolverControls controls = world_get_rd_controls(world);
+    controls.signals.diffusion = 0.24f;
+    controls.signals.decay = 0.1f;
+
+    char err[256];
+    bool ok = world_set_rd_controls(world, &controls, err, sizeof(err));
+    ASSERT(!ok, "invalid controls should fail");
+    ASSERT(strstr(err, "unstable") != NULL, "expected unstable diagnostic");
+
+    world_destroy(world);
+}
+
+int run_rd_controls_tests(void) {
+    tests_passed = 0;
+    tests_failed = 0;
+
+    printf("\n=== Reaction-Diffusion Controls Tests ===\n\n");
+    RUN_TEST(custom_toxin_decay_uses_configured_coefficient);
+    RUN_TEST(signal_diffusion_decay_matches_reference_stencil);
+    RUN_TEST(unstable_solver_controls_are_rejected);
+
+    printf("\n--- Reaction-Diffusion Controls Results ---\n");
+    printf("Passed: %d\n", tests_passed);
+    printf("Failed: %d\n", tests_failed);
+
+    return tests_failed;
+}
+
+#ifdef STANDALONE_TEST
+int main(void) {
+    return run_rd_controls_tests() > 0 ? 1 : 0;
+}
+#endif

--- a/tests/test_simd_eval.c
+++ b/tests/test_simd_eval.c
@@ -49,9 +49,10 @@ static double now_ms(void) {
     return (double)ts.tv_sec * 1000.0 + (double)ts.tv_nsec / 1000000.0;
 }
 
-static void scalar_decay_clamp(float* values, int count, float sub) {
+static void scalar_decay_mul(float* values, int count, float decay) {
+    float factor = 1.0f - decay;
     for (int i = 0; i < count; i++) {
-        values[i] = utils_clamp_f(values[i] - sub, 0.0f, 1.0f);
+        values[i] = utils_clamp_f(values[i] * factor, 0.0f, 1.0f);
     }
 }
 
@@ -77,7 +78,7 @@ TEST(simd_decay_toxins_matches_scalar_reference) {
     }
 
     simulation_decay_toxins(world);
-    scalar_decay_clamp(expected, total, 0.01f);
+    scalar_decay_mul(expected, total, world->rd_controls.toxins.decay);
 
     for (int i = 0; i < total; i++) {
         float diff = fabsf(world->toxins[i] - expected[i]);
@@ -181,7 +182,7 @@ TEST(simd_decay_toxins_performance_eval) {
 
     // Warmup
     simulation_decay_toxins(world);
-    scalar_decay_clamp(scalar_buf, total, 0.01f);
+    scalar_decay_mul(scalar_buf, total, world->rd_controls.toxins.decay);
 
     // Reset
     rng_seed(999);
@@ -196,7 +197,7 @@ TEST(simd_decay_toxins_performance_eval) {
     double t1 = now_ms();
 
     double t2 = now_ms();
-    for (int i = 0; i < iters; i++) scalar_decay_clamp(scalar_buf, total, 0.01f);
+    for (int i = 0; i < iters; i++) scalar_decay_mul(scalar_buf, total, world->rd_controls.toxins.decay);
     double t3 = now_ms();
 
     double simd_ms = t1 - t0;
@@ -234,4 +235,3 @@ int main(void) {
     return run_simd_eval_tests() > 0 ? 1 : 0;
 }
 #endif
-


### PR DESCRIPTION
## Summary
- add explicit per-field reaction-diffusion controls (nutrients/toxins/signals) to world state, CLI configuration, and server reset flows
- implement solver guardrails and stability validation (`diffusion in [0,0.25]`, `decay in [0,1]`, and `4*diffusion + decay <= 1`) with startup rejection for unstable parameter sets
- update environmental update paths to use configurable diffusion/decay and add tests/docs for correctness and rejection behavior

## Testing
- cmake --build build
- ctest --test-dir build --output-on-failure -R "RdControlsTests|SimdEvalTests"

Closes #50