### PR TITLE
metrics: implement frontier genetics telemetry

### DIFF
--- a/docs/GENETICS.md
+++ b/docs/GENETICS.md
@@ -1105,6 +1105,31 @@ colony.parent_id  // 0 if original, else parent colony ID
 
 This enables future features like family trees and ancestry analysis.
 
+## Frontier Genetics Telemetry
+
+Ferox exposes per-tick frontier genetics telemetry for seeded runs. The reference implementation is in `src/server/frontier_metrics.c` and is consumed in `tests/test_performance_eval.c`.
+
+### Output Format
+
+Telemetry is emitted in logfmt key-value format so it remains machine-readable while matching existing perf logging style:
+
+```text
+[perf] frontier_telemetry seed=48048 tick=30 frontier_sector_count=12 lineage_diversity_proxy=0.643112 lineage_entropy_bits=2.418337 frontier_cells=1984 occupied_cells=10954 active_lineages=7
+```
+
+### Definitions and Units
+
+| Metric | Definition | Units | Range |
+|--------|------------|-------|-------|
+| `frontier_sector_count` | Number of occupied angular sectors (16 total) that contain at least one frontier cell around world occupancy centroid | sectors | 0-16 |
+| `lineage_diversity_proxy` | Frontier heterozygosity proxy: `1 - Σ(p_i^2)` over root-lineage shares on frontier cells | unitless | 0-1 |
+| `lineage_entropy_bits` | Shannon entropy across root-lineage shares over all occupied cells: `-Σ(p_i log2 p_i)` | bits | >=0 |
+
+Additional metadata fields in each sample:
+- `seed`: RNG seed used to initialize run.
+- `tick`: simulation tick for the sample.
+- `frontier_cells`, `occupied_cells`, `active_lineages`: supporting counts for analysis.
+
 ## Colony Visualization System
 
 Colonies in Ferox are rendered using **cell-based rendering**, where each cell in the simulation grid is drawn directly. This provides accurate territory visualization.

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(ferox_server_lib STATIC
     atomic_sim.c
+    frontier_metrics.c
     genetics.c
     parallel.c
     server.c

--- a/src/server/frontier_metrics.c
+++ b/src/server/frontier_metrics.c
@@ -1,0 +1,209 @@
+#include "frontier_metrics.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define TWO_PI 6.28318530717958647692
+
+typedef struct {
+    uint32_t lineage_id;
+    size_t count;
+} LineageCount;
+
+static const Colony* find_colony_any(const World* world, uint32_t id) {
+    if (!world || id == 0) {
+        return NULL;
+    }
+
+    for (size_t i = 0; i < world->colony_count; i++) {
+        if (world->colonies[i].id == id) {
+            return &world->colonies[i];
+        }
+    }
+    return NULL;
+}
+
+static uint32_t resolve_root_lineage_id(const World* world, uint32_t colony_id) {
+    if (!world || colony_id == 0) {
+        return 0;
+    }
+
+    uint32_t current = colony_id;
+    size_t guard = world->colony_count + 1;
+
+    while (guard-- > 0) {
+        const Colony* colony = find_colony_any(world, current);
+        if (!colony || colony->parent_id == 0) {
+            return current;
+        }
+        current = colony->parent_id;
+    }
+
+    return colony_id;
+}
+
+static void increment_lineage_count(LineageCount* counts, size_t* used, uint32_t lineage_id) {
+    for (size_t i = 0; i < *used; i++) {
+        if (counts[i].lineage_id == lineage_id) {
+            counts[i].count++;
+            return;
+        }
+    }
+
+    counts[*used].lineage_id = lineage_id;
+    counts[*used].count = 1;
+    (*used)++;
+}
+
+static bool is_frontier_cell(const World* world, int x, int y, uint32_t colony_id) {
+    static const int dx4[4] = {0, 1, 0, -1};
+    static const int dy4[4] = {-1, 0, 1, 0};
+
+    for (int i = 0; i < 4; i++) {
+        int nx = x + dx4[i];
+        int ny = y + dy4[i];
+        if (nx < 0 || nx >= world->width || ny < 0 || ny >= world->height) {
+            continue;
+        }
+
+        uint32_t neighbor = world->cells[ny * world->width + nx].colony_id;
+        if (neighbor != colony_id) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool frontier_telemetry_compute(const World* world, uint32_t seed, FrontierTelemetry* out) {
+    if (!world || !out || world->width <= 0 || world->height <= 0) {
+        return false;
+    }
+
+    memset(out, 0, sizeof(*out));
+    out->seed = seed;
+    out->tick = world->tick;
+
+    size_t lineage_capacity = world->colony_count > 0 ? world->colony_count : 1;
+    LineageCount* total_counts = (LineageCount*)calloc(lineage_capacity, sizeof(LineageCount));
+    LineageCount* frontier_counts = (LineageCount*)calloc(lineage_capacity, sizeof(LineageCount));
+    if (!total_counts || !frontier_counts) {
+        free(total_counts);
+        free(frontier_counts);
+        return false;
+    }
+
+    size_t total_used = 0;
+    size_t frontier_used = 0;
+    double sum_x = 0.0;
+    double sum_y = 0.0;
+
+    for (int y = 0; y < world->height; y++) {
+        for (int x = 0; x < world->width; x++) {
+            uint32_t colony_id = world->cells[y * world->width + x].colony_id;
+            if (colony_id == 0) {
+                continue;
+            }
+
+            uint32_t lineage_id = resolve_root_lineage_id(world, colony_id);
+            increment_lineage_count(total_counts, &total_used, lineage_id);
+
+            out->occupied_cells++;
+            sum_x += (double)x;
+            sum_y += (double)y;
+        }
+    }
+
+    out->active_lineages = total_used;
+
+    bool sector_seen[FRONTIER_TELEMETRY_SECTORS] = {false};
+    double center_x = out->occupied_cells > 0 ? (sum_x / (double)out->occupied_cells) : 0.0;
+    double center_y = out->occupied_cells > 0 ? (sum_y / (double)out->occupied_cells) : 0.0;
+    const double sector_size = TWO_PI / (double)FRONTIER_TELEMETRY_SECTORS;
+
+    for (int y = 0; y < world->height; y++) {
+        for (int x = 0; x < world->width; x++) {
+            uint32_t colony_id = world->cells[y * world->width + x].colony_id;
+            if (colony_id == 0 || !is_frontier_cell(world, x, y, colony_id)) {
+                continue;
+            }
+
+            out->frontier_cells++;
+            uint32_t lineage_id = resolve_root_lineage_id(world, colony_id);
+            increment_lineage_count(frontier_counts, &frontier_used, lineage_id);
+
+            double dx = (double)x - center_x;
+            double dy = (double)y - center_y;
+            double angle = atan2(dy, dx);
+            if (angle < 0.0) {
+                angle += TWO_PI;
+            }
+
+            int sector = (int)(angle / sector_size);
+            if (sector < 0) {
+                sector = 0;
+            } else if (sector >= FRONTIER_TELEMETRY_SECTORS) {
+                sector = FRONTIER_TELEMETRY_SECTORS - 1;
+            }
+            sector_seen[sector] = true;
+        }
+    }
+
+    for (int i = 0; i < FRONTIER_TELEMETRY_SECTORS; i++) {
+        if (sector_seen[i]) {
+            out->frontier_sector_count++;
+        }
+    }
+
+    if (out->frontier_cells > 0) {
+        double inv = 1.0 / (double)out->frontier_cells;
+        double concentration = 0.0;
+        for (size_t i = 0; i < frontier_used; i++) {
+            double p = (double)frontier_counts[i].count * inv;
+            concentration += p * p;
+        }
+        out->lineage_diversity_proxy = (float)(1.0 - concentration);
+    }
+
+    if (out->occupied_cells > 0) {
+        double inv = 1.0 / (double)out->occupied_cells;
+        double entropy = 0.0;
+        for (size_t i = 0; i < total_used; i++) {
+            double p = (double)total_counts[i].count * inv;
+            if (p > 0.0) {
+                entropy -= p * (log(p) / log(2.0));
+            }
+        }
+        out->lineage_entropy_bits = (float)entropy;
+    }
+
+    free(total_counts);
+    free(frontier_counts);
+    return true;
+}
+
+int frontier_telemetry_format_logfmt(const FrontierTelemetry* sample, char* buffer, size_t buffer_size) {
+    if (!sample || !buffer || buffer_size == 0) {
+        return -1;
+    }
+
+    int written = snprintf(
+        buffer,
+        buffer_size,
+        "seed=%u tick=%llu frontier_sector_count=%u lineage_diversity_proxy=%.6f lineage_entropy_bits=%.6f frontier_cells=%zu occupied_cells=%zu active_lineages=%zu",
+        sample->seed,
+        (unsigned long long)sample->tick,
+        sample->frontier_sector_count,
+        sample->lineage_diversity_proxy,
+        sample->lineage_entropy_bits,
+        sample->frontier_cells,
+        sample->occupied_cells,
+        sample->active_lineages);
+
+    if (written < 0 || (size_t)written >= buffer_size) {
+        return -1;
+    }
+    return written;
+}

--- a/src/server/frontier_metrics.h
+++ b/src/server/frontier_metrics.h
@@ -1,0 +1,26 @@
+#ifndef FEROX_FRONTIER_METRICS_H
+#define FEROX_FRONTIER_METRICS_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "world.h"
+
+#define FRONTIER_TELEMETRY_SECTORS 16
+
+typedef struct {
+    uint32_t seed;
+    uint64_t tick;
+    uint32_t frontier_sector_count;
+    float lineage_diversity_proxy;
+    float lineage_entropy_bits;
+    size_t frontier_cells;
+    size_t occupied_cells;
+    size_t active_lineages;
+} FrontierTelemetry;
+
+bool frontier_telemetry_compute(const World* world, uint32_t seed, FrontierTelemetry* out);
+int frontier_telemetry_format_logfmt(const FrontierTelemetry* sample, char* buffer, size_t buffer_size);
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -100,6 +100,12 @@ target_link_libraries(test_monod_kinetics PRIVATE ferox_server_lib)
 target_compile_definitions(test_monod_kinetics PRIVATE STANDALONE_TEST)
 add_test(NAME MonodKineticsTests COMMAND test_monod_kinetics)
 
+# Frontier genetics telemetry tests
+add_executable(test_frontier_metrics test_frontier_metrics.c)
+target_link_libraries(test_frontier_metrics PRIVATE ferox_server_lib)
+target_compile_definitions(test_frontier_metrics PRIVATE STANDALONE_TEST)
+add_test(NAME FrontierMetricsTests COMMAND test_frontier_metrics)
+
 # Visual stability stress tests
 add_executable(test_visual_stability test_visual_stability.c)
 target_link_libraries(test_visual_stability PRIVATE ferox_server_lib)

--- a/tests/test_frontier_metrics.c
+++ b/tests/test_frontier_metrics.c
@@ -1,0 +1,168 @@
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../src/server/frontier_metrics.h"
+#include "../src/server/simulation.h"
+#include "../src/server/world.h"
+#include "../src/shared/utils.h"
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name) static void test_##name(void)
+#define RUN_TEST(name) do { \
+    int failed_before = tests_failed; \
+    printf("  Running %s... ", #name); \
+    fflush(stdout); \
+    test_##name(); \
+    if (tests_failed == failed_before) { \
+        printf("PASSED\n"); \
+        tests_passed++; \
+    } \
+} while (0)
+
+#define ASSERT(cond, msg) do { \
+    if (!(cond)) { \
+        printf("FAILED\n    %s\n    At %s:%d\n", msg, __FILE__, __LINE__); \
+        tests_failed++; \
+        return; \
+    } \
+} while (0)
+
+#define ASSERT_EQ(a, b) ASSERT((a) == (b), #a " == " #b)
+#define ASSERT_NEAR(a, b, eps) ASSERT(fabsf((a) - (b)) <= (eps), #a " ~= " #b)
+
+typedef struct {
+    uint32_t sectors[64];
+    float diversity[64];
+    float entropy[64];
+} TelemetrySeries;
+
+static Colony make_colony(uint32_t parent_id) {
+    Colony colony;
+    memset(&colony, 0, sizeof(Colony));
+    colony.parent_id = parent_id;
+    colony.active = true;
+    return colony;
+}
+
+TEST(frontier_fixture_reports_expected_diversity_and_entropy) {
+    World* world = world_create(3, 1);
+    ASSERT(world != NULL, "world created");
+
+    uint32_t a = world_add_colony(world, make_colony(0));
+    uint32_t b = world_add_colony(world, make_colony(0));
+    ASSERT(a != 0 && b != 0, "colonies created");
+
+    world->cells[0].colony_id = a;
+    world->cells[1].colony_id = b;
+
+    FrontierTelemetry sample;
+    ASSERT(frontier_telemetry_compute(world, 77, &sample), "telemetry computed");
+
+    ASSERT_EQ(sample.seed, 77u);
+    ASSERT_EQ(sample.tick, 0u);
+    ASSERT_EQ(sample.occupied_cells, 2u);
+    ASSERT_EQ(sample.frontier_cells, 2u);
+    ASSERT_EQ(sample.active_lineages, 2u);
+    ASSERT_EQ(sample.frontier_sector_count, 2u);
+    ASSERT_NEAR(sample.lineage_diversity_proxy, 0.5f, 0.0001f);
+    ASSERT_NEAR(sample.lineage_entropy_bits, 1.0f, 0.0001f);
+
+    world_destroy(world);
+}
+
+TEST(lineage_entropy_collapses_when_frontier_is_single_root) {
+    World* world = world_create(4, 1);
+    ASSERT(world != NULL, "world created");
+
+    uint32_t root = world_add_colony(world, make_colony(0));
+    uint32_t child_a = world_add_colony(world, make_colony(root));
+    uint32_t child_b = world_add_colony(world, make_colony(root));
+    ASSERT(root != 0 && child_a != 0 && child_b != 0, "lineage tree created");
+
+    world->cells[0].colony_id = child_a;
+    world->cells[1].colony_id = child_b;
+
+    FrontierTelemetry sample;
+    ASSERT(frontier_telemetry_compute(world, 99, &sample), "telemetry computed");
+
+    ASSERT_EQ(sample.active_lineages, 1u);
+    ASSERT_NEAR(sample.lineage_diversity_proxy, 0.0f, 0.0001f);
+    ASSERT_NEAR(sample.lineage_entropy_bits, 0.0f, 0.0001f);
+
+    world_destroy(world);
+}
+
+static int collect_seeded_series(uint32_t seed, TelemetrySeries* out) {
+    World* world = world_create(64, 40);
+    if (!world) {
+        return 0;
+    }
+
+    srand(seed);
+    rng_seed(seed);
+    world_init_random_colonies(world, 12);
+
+    for (int tick = 0; tick < 64; tick++) {
+        simulation_tick(world);
+
+        FrontierTelemetry sample;
+        if (!frontier_telemetry_compute(world, seed, &sample)) {
+            world_destroy(world);
+            return 0;
+        }
+
+        out->sectors[tick] = sample.frontier_sector_count;
+        out->diversity[tick] = sample.lineage_diversity_proxy;
+        out->entropy[tick] = sample.lineage_entropy_bits;
+
+        if (!(sample.lineage_diversity_proxy >= 0.0f && sample.lineage_diversity_proxy <= 1.0f)) {
+            world_destroy(world);
+            return 0;
+        }
+        if (!(sample.lineage_entropy_bits >= 0.0f)) {
+            world_destroy(world);
+            return 0;
+        }
+    }
+
+    world_destroy(world);
+    return 1;
+}
+
+TEST(seed_replay_produces_stable_telemetry_series) {
+    TelemetrySeries a;
+    TelemetrySeries b;
+    memset(&a, 0, sizeof(a));
+    memset(&b, 0, sizeof(b));
+
+    ASSERT(collect_seeded_series(4242u, &a), "first run collected");
+    ASSERT(collect_seeded_series(4242u, &b), "second run collected");
+
+    for (int i = 0; i < 64; i++) {
+        ASSERT_EQ(a.sectors[i], b.sectors[i]);
+        ASSERT_NEAR(a.diversity[i], b.diversity[i], 0.0001f);
+        ASSERT_NEAR(a.entropy[i], b.entropy[i], 0.0001f);
+    }
+}
+
+int run_frontier_metrics_tests(void) {
+    tests_passed = 0;
+    tests_failed = 0;
+
+    printf("\n=== Frontier Metrics Tests ===\n");
+
+    RUN_TEST(frontier_fixture_reports_expected_diversity_and_entropy);
+    RUN_TEST(lineage_entropy_collapses_when_frontier_is_single_root);
+    RUN_TEST(seed_replay_produces_stable_telemetry_series);
+
+    printf("\nFrontier Metrics Tests: %d passed, %d failed\n", tests_passed, tests_failed);
+    return tests_failed;
+}
+
+int main(void) {
+    return run_frontier_metrics_tests() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/test_performance_eval.c
+++ b/tests/test_performance_eval.c
@@ -16,6 +16,7 @@
 #include "../src/shared/protocol.h"
 #include "../src/server/world.h"
 #include "../src/server/genetics.h"
+#include "../src/server/frontier_metrics.h"
 #include "../src/server/simulation.h"
 #include "../src/server/threadpool.h"
 #include "../src/server/atomic_sim.h"
@@ -293,6 +294,44 @@ TEST(simulation_tick_throughput) {
     world_destroy(world);
 }
 
+TEST(frontier_telemetry_seeded_run_eval) {
+    const int scale = get_perf_scale();
+    const int ticks = 30 * scale;
+    const uint32_t seed = 48048u;
+
+    World* world = create_seeded_world(220, 140, 40, seed);
+    ASSERT_NOT_NULL(world);
+
+    FrontierTelemetry sample;
+    char telemetry_line[256];
+    double start = now_ms();
+
+    printf("    [perf] frontier telemetry csv: seed,tick,frontier_sector_count,lineage_diversity_proxy,lineage_entropy_bits\n");
+
+    for (int i = 0; i < ticks; i++) {
+        simulation_tick(world);
+        ASSERT(frontier_telemetry_compute(world, seed, &sample), "frontier telemetry computed");
+
+        ASSERT(sample.frontier_sector_count <= FRONTIER_TELEMETRY_SECTORS,
+               "frontier sector count should be bounded");
+        ASSERT(sample.lineage_diversity_proxy >= 0.0f && sample.lineage_diversity_proxy <= 1.0f,
+               "lineage diversity proxy should be normalized");
+        ASSERT(sample.lineage_entropy_bits >= 0.0f,
+               "lineage entropy should be non-negative");
+
+        if ((i + 1) % 10 == 0) {
+            ASSERT(frontier_telemetry_format_logfmt(&sample, telemetry_line, sizeof(telemetry_line)) > 0,
+                   "telemetry line formatting succeeds");
+            printf("    [perf] frontier_telemetry %s\n", telemetry_line);
+        }
+    }
+
+    double elapsed = now_ms() - start;
+    print_metric("frontier telemetry compute", elapsed, (double)ticks);
+
+    world_destroy(world);
+}
+
 TEST(atomic_tick_throughput_and_speedup_eval) {
     const int scale = get_perf_scale();
     const int ticks = 30 * scale;
@@ -463,6 +502,7 @@ int run_performance_eval_tests(void) {
     RUN_TEST(protocol_world_serialize_deserialize_throughput);
     RUN_TEST(protocol_world_path_breakdown_eval);
     RUN_TEST(simulation_tick_throughput);
+    RUN_TEST(frontier_telemetry_seeded_run_eval);
     RUN_TEST(atomic_tick_throughput_and_speedup_eval);
     RUN_TEST(atomic_tick_thread_scaling_eval);
     RUN_TEST(threadpool_task_throughput);


### PR DESCRIPTION
## Summary
- Add `frontier_metrics` telemetry for per-tick frontier sector coverage, lineage diversity proxy (heterozygosity), and lineage entropy with seed/tick metadata.
- Emit machine-readable logfmt telemetry in the existing `[perf]` stream via a seeded performance eval benchmark, with built-in correctness bounds validation.
- Add deterministic fixture + seeded replay tests for metric correctness/stability and document definitions, formulas, and units.

Closes #48.