### PR TITLE
perf: reduce small-pool atomic scheduling overhead

### DIFF
--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -14,7 +14,37 @@ FEROX_PERF_SCALE=5 ./scripts/test.sh perf
 
 `FEROX_PERF_SCALE` increases loop counts in `test_performance_eval.c` so timings are more stable.
 
-## Current Baseline (macOS arm64, 3 runs, `FEROX_PERF_SCALE=5`)
+## Current Baseline (macOS arm64, scenario runs on 2026-03-05)
+
+Fresh scenario runs were executed with:
+
+```bash
+python3 scripts/perf_scenarios.py --build-types Debug Release --scales 1 2 --repeats 2
+```
+
+Key observations from `artifacts/perf/20260305-133809/`:
+
+- Release:
+  - atomic/serial ratio: **1.52x**
+  - tiny/batched threadpool ratio: **4.07x**
+- Debug:
+  - atomic/serial ratio: **1.64x**
+  - tiny/batched threadpool ratio: **4.96x**
+
+Selected medians:
+
+- `debug_scale2` `atomic_tick (1 thread)`: **2715.78 ms**
+- `debug_scale2` `atomic_tick (2 threads)`: **1658.02 ms**
+- `debug_scale2` `atomic_tick (4 threads)`: **1379.82 ms**
+- `debug_scale2` `simulation_tick (serial)`: **1232.58 ms**
+
+Interpretation:
+
+- The atomic path is still structurally slower than serial for the current grid sizes.
+- Small-task scheduling overhead remains a first-order cost.
+- One near-term improvement is to avoid oversharding the atomic region decomposition for 1-thread and 2-thread runs.
+
+## Previous Baseline (macOS arm64, 3 runs, `FEROX_PERF_SCALE=5`)
 
 Average values from repeated runs:
 

--- a/src/server/atomic_sim.c
+++ b/src/server/atomic_sim.c
@@ -99,6 +99,22 @@ static inline float deterministic_float(
     return (float)(mix_u32(mixed) & 0x00FFFFFFu) / 16777216.0f;
 }
 
+static void atomic_region_layout(const AtomicWorld* aworld, int* regions_x, int* regions_y) {
+    if (aworld->thread_count <= 1) {
+        *regions_x = 1;
+        *regions_y = 1;
+    } else if (aworld->thread_count == 2) {
+        *regions_x = 2;
+        *regions_y = 1;
+    } else if (aworld->thread_count <= 4) {
+        *regions_x = aworld->thread_count;
+        *regions_y = 1;
+    } else {
+        *regions_x = 4;
+        *regions_y = 4;
+    }
+}
+
 static inline float monod_saturation(float substrate, float half_saturation) {
     if (substrate <= 0.0f) return 0.0f;
     if (half_saturation <= 0.0f) return 1.0f;
@@ -550,8 +566,10 @@ AtomicWorld* atomic_world_create(World* world, ThreadPool* pool, int thread_coun
                 ((uint32_t)world->height * 0xc2b2ae35u));
     
     // Preallocate region work items
-    int regions_per_side = thread_count > 4 ? 4 : 2;
-    aworld->region_work_count = regions_per_side * regions_per_side;
+    int regions_x = 1;
+    int regions_y = 1;
+    atomic_region_layout(aworld, &regions_x, &regions_y);
+    aworld->region_work_count = regions_x * regions_y;
     aworld->region_work = (AtomicRegionWork*)calloc(aworld->region_work_count, sizeof(AtomicRegionWork));
     if (!aworld->region_work) {
         free(aworld->colony_stats);
@@ -832,11 +850,11 @@ void atomic_age_region(AtomicRegionWork* work) {
 // Parallel Phases
 // ============================================================================
 
-static void submit_region_tasks(AtomicWorld* aworld, void (*task_func)(void*)) {
-    int regions_per_side = aworld->thread_count > 4 ? 4 : 2;
-    int regions_x = regions_per_side;
-    int regions_y = regions_per_side;
-    
+static int prepare_region_tasks(AtomicWorld* aworld) {
+    int regions_x = 1;
+    int regions_y = 1;
+    atomic_region_layout(aworld, &regions_x, &regions_y);
+
     int region_width = aworld->grid.width / regions_x;
     int region_height = aworld->grid.height / regions_y;
     
@@ -853,9 +871,23 @@ static void submit_region_tasks(AtomicWorld* aworld, void (*task_func)(void*)) {
             work->end_y = (ry == regions_y - 1) ? aworld->grid.height : (ry + 1) * region_height;
             work->thread_id = task_idx % aworld->thread_count;
             task_idx++;
-            
-            threadpool_submit(aworld->pool, task_func, work);
         }
+    }
+    return task_idx;
+}
+
+static void submit_region_tasks(AtomicWorld* aworld, void (*task_func)(void*)) {
+    int task_count = prepare_region_tasks(aworld);
+
+    if (aworld->thread_count == 1) {
+        for (int i = 0; i < task_count; i++) {
+            task_func(&aworld->region_work[i]);
+        }
+        return;
+    }
+
+    for (int i = 0; i < task_count; i++) {
+        threadpool_submit(aworld->pool, task_func, &aworld->region_work[i]);
     }
 }
 


### PR DESCRIPTION
Closes #76

## Summary
- make atomic region decomposition follow thread count for small pools
- bypass queue submission for 1-thread atomic runs
- update performance documentation with the fresh 2026-03-05 baseline and observed comparison data
- add branch-local review documentation

## Verification
- ctest --output-on-failure -R "PerformanceEvalTests" -V

## Observed release comparison
- atomic_tick (4 threads): 94.28 ms -> 89.30 ms
- 4-thread speedup vs 1-thread: 2.14x -> 2.57x
- tiny/batched ratio: 3.51x -> 3.42x