### PR TITLE
fix: implement spawn command and reduce broadcast lock time

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,8 +4,8 @@ This document describes the technical architecture of the Ferox bacterial colony
 
 ## Current Implementation Notes
 
-- The server currently broadcasts full `MSG_WORLD_STATE` snapshots each tick; `MSG_WORLD_DELTA` exists in protocol definitions but is not emitted by `server.c`.
-- Command handling is implemented for pause/resume/speed/reset/select; `CMD_SPAWN_COLONY` is currently logged but not applied to world state.
+- The server currently broadcasts full `MSG_WORLD_STATE` snapshots each tick; `MSG_WORLD_DELTA` remains reserved for future protocol work and is not emitted by `server.c`.
+- Command handling is implemented for pause/resume/speed/reset/select/spawn.
 - TUI and GUI share protocol/state parity for core controls, but GUI has extra interaction features (mouse selection, zoom, grid/info toggles) and TUI alone has `--demo`.
 - `scripts/run.sh` normalizes client/server startup around port `8765` and only auto-kills existing listeners when they are `ferox_server` processes.
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -65,7 +65,7 @@ typedef enum MessageType {
     MSG_CONNECT     = 0,  // Client -> Server: connection request
     MSG_DISCONNECT  = 1,  // Client -> Server: graceful disconnect
     MSG_WORLD_STATE = 2,  // Server -> Client: full world state
-    MSG_WORLD_DELTA = 3,  // Server -> Client: incremental update
+    MSG_WORLD_DELTA = 3,  // Server -> Client: reserved for future incremental update support
     MSG_COLONY_INFO = 4,  // Server -> Client: detailed colony info
     MSG_COMMAND     = 5,  // Client -> Server: user command
     MSG_ACK         = 6,  // Bidirectional: acknowledgment
@@ -260,10 +260,10 @@ int proto_world_alloc_grid(proto_world* world, int width, int height);
 
 ### MSG_WORLD_DELTA (Type 3)
 
-Incremental update containing only changed cells. (Reserved for future optimization)
+Reserved for future incremental updates.
 
 **Direction:** Server → Client  
-**Status:** Not yet implemented
+**Status:** Not yet implemented. Current server builds emit full `MSG_WORLD_STATE` snapshots only.
 
 ---
 

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -5,7 +5,9 @@
 
 #include "server.h"
 #include "simulation.h"
+#include "genetics.h"
 #include "parallel.h"
+#include "../shared/names.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -23,6 +25,7 @@
 static void* accept_thread_func(void* arg);
 static void* simulation_thread_func(void* arg);
 static bool server_rebuild_world_state(Server* server, int width, int height, int initial_colonies);
+static bool server_spawn_colony(Server* server, const CommandSpawnColony* spawn);
 
 // Helper to get current time in milliseconds
 static long get_time_ms(void) {
@@ -468,42 +471,56 @@ void server_broadcast_world_state(Server* server) {
         return;
     }
     
-    // Broadcast to all clients
+    // Snapshot clients under lock so socket I/O does not block client-list mutation.
+    client_session** snapshot = NULL;
+    int snapshot_count = 0;
+    pthread_mutex_lock(&server->clients_mutex);
+    if (server->client_count > 0) {
+        snapshot = (client_session**)calloc((size_t)server->client_count, sizeof(client_session*));
+        if (snapshot) {
+            client_session* client = server->clients;
+            while (client && snapshot_count < server->client_count) {
+                snapshot[snapshot_count++] = client;
+                client = client->next;
+            }
+        }
+    }
+    pthread_mutex_unlock(&server->clients_mutex);
+
+    for (int i = 0; i < snapshot_count; i++) {
+        client_session* client = snapshot[i];
+        if (!client || !client->active || !client->socket || !client->socket->connected) continue;
+        if (protocol_send_message(client->socket->fd, MSG_WORLD_STATE, buffer, len) < 0) {
+            printf("Client %u disconnected\n", client->id);
+            client->active = false;
+        }
+    }
+
     pthread_mutex_lock(&server->clients_mutex);
     client_session* client = server->clients;
     client_session* prev = NULL;
-    
     while (client) {
         client_session* next = client->next;
-        
-        if (client->active && client->socket && client->socket->connected) {
-            int result = protocol_send_message(client->socket->fd, MSG_WORLD_STATE, buffer, len);
-            if (result < 0) {
-                // Client disconnected
-                printf("Client %u disconnected\n", client->id);
-                client->active = false;
-                
-                // Remove from list
-                if (prev) {
-                    prev->next = next;
-                } else {
-                    server->clients = next;
-                }
-                
-                net_socket_close(client->socket);
-                free(client);
-                server->client_count--;
-                
-                client = next;
-                continue;
+        if (!client->active || !client->socket || !client->socket->connected) {
+            if (prev) {
+                prev->next = next;
+            } else {
+                server->clients = next;
             }
+            if (client->socket) {
+                net_socket_close(client->socket);
+            }
+            free(client);
+            server->client_count--;
+            client = next;
+            continue;
         }
-        
         prev = client;
         client = next;
     }
     pthread_mutex_unlock(&server->clients_mutex);
     
+    free(snapshot);
     free(buffer);
     proto_world_free(&proto_world);
 }
@@ -596,13 +613,62 @@ void server_handle_command(Server* server, client_session* client, CommandType c
         case CMD_SPAWN_COLONY:
             if (data) {
                 CommandSpawnColony* spawn = (CommandSpawnColony*)data;
-                // Create a simple colony at the specified position
-                // This would need proper implementation using world_add_colony
-                printf("Spawn colony request at (%.1f, %.1f) by client %u\n", 
-                       spawn->x, spawn->y, client->id);
+                if (server_spawn_colony(server, spawn)) {
+                    printf("Spawned colony at (%.1f, %.1f) for client %u\n",
+                           spawn->x, spawn->y, client->id);
+                } else {
+                    printf("Spawn colony request rejected at (%.1f, %.1f) by client %u\n",
+                           spawn->x, spawn->y, client->id);
+                }
             }
             break;
     }
+}
+
+static bool server_spawn_colony(Server* server, const CommandSpawnColony* spawn) {
+    if (!server || !server->world || !spawn) return false;
+
+    int x = (int)spawn->x;
+    int y = (int)spawn->y;
+    Cell* cell = world_get_cell(server->world, x, y);
+    if (!cell || cell->colony_id != 0) return false;
+
+    Colony colony;
+    memset(&colony, 0, sizeof(colony));
+    colony.genome = genome_create_random();
+    colony.color = colony.genome.body_color;
+    colony.cell_count = 1;
+    colony.max_cell_count = 1;
+    colony.active = true;
+    colony.shape_seed = (uint32_t)rand() ^ ((uint32_t)rand() << 16);
+    colony.wobble_phase = (float)(rand() % 628) / 100.0f;
+    colony.shape_evolution = (float)(rand() % 1000) / 1000.0f;
+    colony.state = COLONY_STATE_NORMAL;
+
+    if (spawn->name[0] != '\0') {
+        strncpy(colony.name, spawn->name, sizeof(colony.name) - 1);
+        colony.name[sizeof(colony.name) - 1] = '\0';
+    } else {
+        generate_scientific_name(colony.name, sizeof(colony.name));
+    }
+
+    uint32_t id = world_add_colony(server->world, colony);
+    if (id == 0) return false;
+
+    cell->colony_id = id;
+    cell->age = 0;
+    cell->is_border = true;
+
+    Colony* added = world_get_colony(server->world, id);
+    if (added) {
+        added->cell_count = 1;
+        added->max_cell_count = 1;
+    }
+
+    if (server->atomic_world) {
+        atomic_world_sync_from_world(server->atomic_world);
+    }
+    return true;
 }
 
 client_session* server_add_client(Server* server, net_socket* socket) {

--- a/src/shared/protocol.h
+++ b/src/shared/protocol.h
@@ -17,7 +17,7 @@ typedef enum MessageType {
     MSG_CONNECT,        // Client -> Server: request connection
     MSG_DISCONNECT,     // Client -> Server: disconnect
     MSG_WORLD_STATE,    // Server -> Client: full world state
-    MSG_WORLD_DELTA,    // Server -> Client: changes since last update
+    MSG_WORLD_DELTA,    // Server -> Client: reserved for future delta updates
     MSG_COLONY_INFO,    // Server -> Client: detailed colony info
     MSG_COMMAND,        // Client -> Server: user command
     MSG_ACK,            // Acknowledgment

--- a/tests/test_phase5.c
+++ b/tests/test_phase5.c
@@ -184,6 +184,35 @@ int test_server_handles_pause_resume_commands(void) {
     return 0;
 }
 
+int test_server_handles_spawn_colony_command(void) {
+    Server* server = server_create(0, 50, 50, 2);
+    TEST_ASSERT(server != NULL, "Server should be created");
+
+    net_socket* mock_socket = (net_socket*)calloc(1, sizeof(net_socket));
+    mock_socket->fd = -1;
+    mock_socket->connected = true;
+    client_session* client = server_add_client(server, mock_socket);
+    TEST_ASSERT(client != NULL, "Client should be added");
+
+    size_t before_count = server->world->colony_count;
+    CommandSpawnColony spawn_cmd = { .x = 10.0f, .y = 12.0f };
+    strncpy(spawn_cmd.name, "Issue75", MAX_COLONY_NAME - 1);
+    spawn_cmd.name[MAX_COLONY_NAME - 1] = '\0';
+
+    server_handle_command(server, client, CMD_SPAWN_COLONY, &spawn_cmd);
+
+    TEST_ASSERT(server->world->colony_count == before_count + 1, "Colony count should increase");
+    Cell* cell = world_get_cell(server->world, 10, 12);
+    TEST_ASSERT(cell != NULL, "Spawn cell should exist");
+    TEST_ASSERT(cell->colony_id != 0, "Spawned cell should be occupied");
+    TEST_ASSERT(atomic_load(&grid_current(&server->atomic_world->grid)[12 * server->world->width + 10].colony_id) == cell->colony_id,
+                "Atomic world should be resynced after spawn");
+
+    server_remove_client(server, client);
+    server_destroy(server);
+    return 0;
+}
+
 // Test: Server port assignment
 int test_server_assigns_unique_ports(void) {
     // Create server on port 0 (auto-assign)
@@ -369,6 +398,7 @@ int main(void) {
     // Command handling tests
     printf("\n--- Command Handling Tests ---\n");
     RUN_TEST(test_server_handles_pause_resume_commands);
+    RUN_TEST(test_server_handles_spawn_colony_command);
     
     // World tests
     printf("\n--- World Tests ---\n");


### PR DESCRIPTION
Closes #75

## Summary
- move world-state socket sends outside the client-list critical section
- implement CMD_SPAWN_COLONY and sync the atomic world after manual spawns
- update protocol and architecture docs to mark MSG_WORLD_DELTA as reserved
- add Phase 5 coverage for spawn handling

## Verification
- ctest --output-on-failure -R "Phase4Tests|Phase5Tests"