### PR TITLE
perf: restore perf/coverage evaluation work through PR flow

### DIFF
--- a/docs/CODEBASE_REVIEW_LOG.md
+++ b/docs/CODEBASE_REVIEW_LOG.md
@@ -232,3 +232,7 @@ Recovery plan:
 - Create a revert branch from `origin/main` that undoes the 8 accidentally pushed commits via normal commits.
 - Open and merge a revert PR so GitHub history returns to the pre-push tree without rewriting protected history.
 - Open a second PR from the preserved feature branch content so CI can run and the changes can be merged through the normal PR path.
+
+Current progress:
+- Revert PR `#81` merged successfully, returning `main` to the pre-push tree through protected-branch-safe history.
+- `feat/perf-eval-coverage-summary` remains published with the preserved feature history and is the next PR base.


### PR DESCRIPTION
## Summary
- restore the perf, coverage, and benchmark instrumentation work through the normal PR path
- keep the review log updated with the protected-main recovery steps
- carry forward the performance evaluation artifacts and supporting tooling that were preserved on the feature branch

## Context
- PR #81 reverted the accidental direct push to protected main.
- This PR reintroduces the preserved feature branch content so CI can validate it through the normal workflow.

## Verification
- prior local worktree validation covered the associated test and performance suites
- this PR is intentionally gated on GitHub Actions before merge