### PR TITLE
ci: fix preview workflow push refspec

### DIFF
--- a/.github/workflows/update-preview-gif.yml
+++ b/.github/workflows/update-preview-gif.yml
@@ -69,4 +69,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add assets/preview.gif
           git commit -m "chore: refresh preview gif"
-          git push origin "HEAD:${{ steps.target.outputs.branch }}"
+          git push origin "HEAD:refs/heads/${{ steps.target.outputs.branch }}"

--- a/docs/CODEBASE_REVIEW_LOG.md
+++ b/docs/CODEBASE_REVIEW_LOG.md
@@ -244,3 +244,11 @@ Progress:
 - Because Release builds compile out `assert`, the helper now also uses `(void)bytes;` so the parameter remains intentionally referenced in all build modes.
 - CI for PR `#84` showed that `count_substring()` is still used by the border/highlight renderer test, so that helper was restored.
 - Release builds also compile out the renderer assertions, so the border/colony counts are now computed into locals and explicitly referenced before assertion checks.
+
+## Preview Workflow Fix
+
+Status: In progress
+
+Progress:
+- The `Update Preview GIF` workflow failed in `Commit updated preview` after checking out a detached `head_sha`.
+- The push refspec now uses `HEAD:refs/heads/<branch>` so Git can push back to branch names containing slashes from a detached checkout.


### PR DESCRIPTION
## Summary
- fix the Update Preview GIF workflow so detached HEAD pushes target a fully qualified branch ref
- document the workflow failure and repair in the running review log

## Root cause
- the workflow checked out a detached commit SHA for workflow_run events
- git push origin "HEAD:<branch>" is ambiguous in that state, especially for branch names containing slashes
- pushing to HEAD:refs/heads/<branch> removes the ambiguity

## Verification
- YAML loads successfully for .github/workflows/update-preview-gif.yml