### PR TITLE
docs: formalize development cycle and tracking workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security policy
+    url: https://github.com/wokuno/ferox/blob/main/SECURITY.md
+    about: Report vulnerabilities privately instead of opening a public issue.
+  - name: Ferox docs index
+    url: https://github.com/wokuno/ferox/blob/main/docs/README.md
+    about: Check architecture, protocol, simulation, and performance docs before filing a new issue.

--- a/.github/ISSUE_TEMPLATE/model_behavior_work.yml
+++ b/.github/ISSUE_TEMPLATE/model_behavior_work.yml
@@ -1,0 +1,59 @@
+name: Model or behavior work
+description: Track ecology, simulation, genetics, or colony-behavior improvements.
+title: "model: "
+labels:
+  - enhancement
+  - tracking
+  - area:model
+  - area:docs
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What biological, ecological, or behavior outcome should improve?
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence and current gaps
+      placeholder: |
+        - docs/SIMULATION.md:...
+        - docs/GENETICS.md:...
+        - src/server/simulation.c:...
+        - tests/test_simulation_logic.c:...
+    validations:
+      required: true
+  - type: textarea
+    id: design
+    attributes:
+      label: Design direction
+      description: Describe the narrow first slice, not the entire dream state.
+    validations:
+      required: true
+  - type: textarea
+    id: metrics
+    attributes:
+      label: Validation and behavior checks
+      description: Which tests, metrics, or scenario runs should confirm the change?
+    validations:
+      required: true
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks and compatibility notes
+      description: Note balance shifts, determinism concerns, protocol/UI implications, or migration needs.
+    validations:
+      required: false
+  - type: checkboxes
+    id: docs
+    attributes:
+      label: Documentation updates
+      options:
+        - label: Update `docs/SIMULATION.md` / `docs/GENETICS.md` / related planning docs in the same PR.
+          required: true
+        - label: Update testing and operator docs if the change adds new knobs, metrics, or workflows.
+          required: true
+        - label: Update README/docs README if the user-facing feature set changes materially.
+          required: false

--- a/.github/ISSUE_TEMPLATE/performance_work.yml
+++ b/.github/ISSUE_TEMPLATE/performance_work.yml
@@ -1,0 +1,75 @@
+name: Performance work
+description: Track runtime, scheduling, memory, or transport performance improvements.
+title: "perf: "
+labels:
+  - enhancement
+  - tracking
+  - area:perf
+  - area:docs
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is slow, scaling poorly, or wasting work today?
+      placeholder: Describe the bottleneck, symptom, or regression clearly.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Link relevant files, docs, profiles, tests, or prior issues.
+      placeholder: |
+        - docs/PERFORMANCE.md:...
+        - src/server/...
+        - tests/test_performance_eval.c:...
+    validations:
+      required: true
+  - type: dropdown
+    id: track
+    attributes:
+      label: Primary track
+      options:
+        - Runtime & Perf
+        - Infra
+        - Network & Protocol
+        - Replay & Science
+        - Ecology & Behavior
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Suggested priority
+      options:
+        - P0
+        - P1
+        - P2
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed direction
+      description: What implementation slice should be tried first?
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation plan
+      description: Which tests, benchmarks, or profiles should prove success?
+    validations:
+      required: true
+  - type: checkboxes
+    id: docs
+    attributes:
+      label: Documentation updates
+      options:
+        - label: Update the relevant planning doc or backlog entry in the same PR.
+          required: true
+        - label: Update affected runtime/spec docs and commands when behavior, defaults, or metrics change.
+          required: true
+        - label: Update README/docs README if the workflow or operator guidance changes.
+          required: false

--- a/.github/ISSUE_TEMPLATE/protocol_transport_work.yml
+++ b/.github/ISSUE_TEMPLATE/protocol_transport_work.yml
@@ -1,0 +1,58 @@
+name: Protocol or transport work
+description: Track wire-format, client/server transport, sync, or compatibility work.
+title: "protocol: "
+labels:
+  - enhancement
+  - tracking
+  - area:protocol
+  - area:network
+  - area:docs
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What protocol or transport limitation is this issue addressing?
+    validations:
+      required: true
+  - type: textarea
+    id: current_behavior
+    attributes:
+      label: Current behavior and evidence
+      placeholder: |
+        - docs/PROTOCOL.md:...
+        - src/shared/protocol.h:...
+        - src/server/server.c:...
+    validations:
+      required: true
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility and rollout notes
+      description: Note versioning, migration, client compatibility, and fallback concerns.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed direction
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation plan
+      description: Include protocol fixtures, client/server tests, and soak/load checks.
+    validations:
+      required: true
+  - type: checkboxes
+    id: docs
+    attributes:
+      label: Documentation updates
+      options:
+        - label: Update `docs/PROTOCOL.md` in the same PR as any wire-format or message-shape change.
+          required: true
+        - label: Update related architecture/testing/operator docs when rollout behavior changes.
+          required: true
+        - label: Update README/docs README if user-visible startup or compatibility expectations change.
+          required: false

--- a/.github/ISSUE_TEMPLATE/science_validation_work.yml
+++ b/.github/ISSUE_TEMPLATE/science_validation_work.yml
@@ -1,0 +1,53 @@
+name: Science or validation work
+description: Track replayability, benchmarks, regression harnesses, or scientific validation work.
+title: "science: "
+labels:
+  - enhancement
+  - tracking
+  - area:science
+  - area:repro
+  - area:docs
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What reproducibility or science-validation capability should this add?
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence and current tooling gaps
+      placeholder: |
+        - docs/SCIENCE_BENCHMARKS.md:...
+        - docs/STATISTICAL_REGRESSION.md:...
+        - tests/test_simulation_stat_regression.c:...
+        - scripts/science_benchmarks.py:...
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Proposed scope
+      description: Describe the executable slice to land first.
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation plan
+      description: Include CI, artifact, and cross-host expectations where relevant.
+    validations:
+      required: true
+  - type: checkboxes
+    id: docs
+    attributes:
+      label: Documentation updates
+      options:
+        - label: Update `docs/SCIENCE_BENCHMARKS.md`, `docs/STATISTICAL_REGRESSION.md`, and related testing docs in the same PR.
+          required: true
+        - label: Document commands, artifact locations, and pass/fail interpretation for operators/contributors.
+          required: true
+        - label: Update README/docs README if this becomes a recommended workflow.
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,46 @@
+## Summary
+- 
+
+## Linked Issues
+- Closes #
+- Refs #
+
+## Type of Change
+- [ ] Performance work
+- [ ] Protocol / transport work
+- [ ] Model / behavior work
+- [ ] Science / validation work
+- [ ] Bug fix
+- [ ] Documentation only
+- [ ] Refactor / maintenance
+
+## What Changed
+- 
+
+## Validation
+- [ ] Relevant CTest / script commands were run
+- [ ] New or updated tests were added where needed
+- [ ] Performance claims use repeated runs or profiler evidence when applicable
+- [ ] Protocol/model changes were checked against the matching docs
+
+Commands run:
+
+```bash
+# paste commands here
+```
+
+## Documentation Updated
+- [ ] Updated the matching planning/backlog doc
+- [ ] Updated affected runtime/spec docs
+- [ ] Updated `docs/README.md` or `README.md` if workflow/user guidance changed
+
+Docs touched:
+- 
+
+## Project Hygiene
+- [ ] Linked issue is in the `Ferox Research Backlog` project
+- [ ] Labels / priority still match the final scope
+- [ ] Follow-up work has a linked issue if not handled here
+
+## Notes for Reviewers
+- 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ Inspect detected hardware and runtime target:
 ## Contributing
 
 See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for development guidelines.
+See [docs/DEVELOPMENT_CYCLE.md](docs/DEVELOPMENT_CYCLE.md) for the issue-driven
+development workflow, GitHub Project usage, validation expectations, and the
+rule that documentation updates land in the same PR as behavior/workflow changes.
 
 ## Hardware Support
 

--- a/docs/COLONY_INTELLIGENCE.md
+++ b/docs/COLONY_INTELLIGENCE.md
@@ -149,3 +149,8 @@ Future selected-colony detail should also expose:
 - `#94` Surface colony state and behavior stats in protocol, CLI, and GUI
 - `#92` Restore colony ecology behavior parity on the atomic runtime path
 - `#87` Implement signal, alarm, and horizontal gene-transfer behaviors
+- `#101` Wire Monod uptake and EPS-dependent transport into the live runtime
+- `#102` Replace heuristic contact HGT with plasmid kinetics and metrics
+- `#103` Split atomic serial maintenance cadence by freshness requirements
+- `#104` Unify neighborhood topology across spread, division, combat, and frontier telemetry
+- `#105` Derive quorum state from signal field, memory, and thresholds

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,6 +6,7 @@ Thank you for your interest in contributing to Ferox! This document provides gui
 
 - [Security](#security)
 - [Development Setup](#development-setup)
+- [Development Cycle](#development-cycle)
 - [Code Style](#code-style)
 - [Commit Message Format](#commit-message-format)
 - [Pull Request Process](#pull-request-process)
@@ -62,6 +63,21 @@ Recommended tools:
 - **clang-tidy**: Static analysis
 - **valgrind**: Memory debugging
 - **gdb/lldb**: Debugging
+
+## Development Cycle
+
+Ferox uses an issue-driven development loop with explicit validation and docs
+follow-through.
+
+- start new work from a GitHub issue template when possible
+- attach the issue to the matching labels, milestone, and GitHub Project track
+- implement a narrow slice rather than a large speculative branch
+- run the matching validation commands before opening a PR
+- update the relevant docs in the same PR as the code change
+
+See `docs/DEVELOPMENT_CYCLE.md` for the full process covering issue intake,
+project tracking, umbrella issues, validation expectations, PR hygiene, and
+merge follow-up.
 
 ## Code Style
 
@@ -250,6 +266,16 @@ docs(api): add API reference documentation
 4. **Run tests**: Ensure all tests pass
 5. **Update docs**: Update relevant documentation
 
+### Issue Templates and Tracking
+
+- Prefer the GitHub issue templates for new work so performance, protocol,
+  model, and science issues all capture evidence, validation, and doc updates in
+  a consistent shape.
+- New backlog work should be attached to the `Research Backlog Sweep` project and
+  use the matching area / priority labels when appropriate.
+- If an issue changes behavior, defaults, metrics, or workflows, call out the
+  required doc updates in the issue body and complete them in the same PR.
+
 ### Branch Naming
 
 | Type | Format | Example |
@@ -261,32 +287,13 @@ docs(api): add API reference documentation
 
 ### Pull Request Template
 
-```markdown
-## Description
-Brief description of changes.
+Use `.github/PULL_REQUEST_TEMPLATE.md`. The PR should clearly cover:
 
-## Type of Change
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Breaking change
-- [ ] Documentation update
-
-## Changes Made
-- Change 1
-- Change 2
-- Change 3
-
-## Testing
-- [ ] All existing tests pass
-- [ ] Added new tests for changes
-- [ ] Tested manually
-
-## Checklist
-- [ ] Code follows project style guidelines
-- [ ] Self-reviewed my code
-- [ ] Updated documentation
-- [ ] No new warnings
-```
+- linked issues
+- scope of the change
+- commands/tests/benchmarks run
+- documentation updated in the same PR
+- any intentional follow-up issues left out of scope
 
 ### Review Process
 

--- a/docs/DEVELOPMENT_CYCLE.md
+++ b/docs/DEVELOPMENT_CYCLE.md
@@ -1,0 +1,172 @@
+# Ferox Development Cycle
+
+This document describes the working development loop for Ferox: how ideas enter
+the backlog, how implementation work is tracked, how validation is expected to
+run, and how documentation stays in sync with code.
+
+## Goals
+
+- keep research, implementation, and follow-up work visible in GitHub
+- make issue scope, validation, and documentation expectations explicit up front
+- avoid landing behavior or workflow changes without matching docs updates
+- keep performance, protocol, and simulation work tied to measurable evidence
+
+## GitHub Operating Model
+
+Ferox currently uses four layers of GitHub tracking:
+
+1. **Issue templates**
+   - new work should start from the matching template in
+     `.github/ISSUE_TEMPLATE/`
+   - templates capture the problem, evidence, proposed direction, validation
+     plan, and required documentation updates
+2. **Labels**
+   - area labels: `area:perf`, `area:threading`, `area:network`,
+     `area:protocol`, `area:model`, `area:science`, `area:repro`, `area:docs`
+   - priority labels: `priority:p0`, `priority:p1`, `priority:p2`
+   - tracking label: `tracking`
+3. **Milestone**
+   - current research sweep milestone: `Research Backlog Sweep`
+4. **GitHub Project**
+   - project: `Ferox Research Backlog`
+   - custom fields: `Track`, `Priority`, and built-in `Status`
+
+## Umbrella Issues
+
+Large workstreams are grouped under umbrella issues so related tasks can evolve
+without losing the bigger picture.
+
+- `#144` simulation runtime and core performance
+- `#145` scheduler, atomics, and memory infrastructure
+- `#146` network transport and protocol evolution
+- `#147` determinism, replayability, and science validation
+- `#148` ecology and colony behavior
+
+Child issues should link back to their umbrella issue, and umbrella issues should
+be updated when sequencing, scope, or dependencies change materially.
+
+## Standard Development Cycle
+
+### 1. Capture
+
+- start with a GitHub issue, not an untracked todo
+- choose the closest issue template
+- include concrete evidence: file references, docs references, tests, profiles,
+  benchmark output, or previous issues
+- call out the narrow first slice rather than a vague long-term ambition
+
+### 2. Triage
+
+- add the correct area and priority labels
+- attach the issue to the `Research Backlog Sweep` milestone when relevant
+- add the issue to the `Ferox Research Backlog` project
+- set `Track`, `Priority`, and initial `Status=Todo`
+- link the issue to its umbrella/meta issue if it belongs to an existing stream
+
+### 3. Prepare
+
+- create a focused branch from `main`
+- confirm the affected docs before changing code
+- identify the validation ladder for the work:
+  - correctness tests
+  - perf/component tests
+  - protocol fixtures
+  - science/regression scenarios
+
+Recommended branch naming:
+
+- `feature/<short-name>`
+- `fix/<short-name>`
+- `perf/<short-name>`
+- `docs/<short-name>`
+- `refactor/<short-name>`
+
+### 4. Implement
+
+- keep the first PR narrow and reversible
+- avoid mixing unrelated cleanup into the same change
+- when touching hot paths or model behavior, preserve a way to compare before vs
+  after behavior
+- if the issue changes defaults, flags, message formats, or workflows, update the
+  docs in the same branch before opening the PR
+
+### 5. Validate
+
+- run the tests that match the issue scope
+- for performance work, prefer repeated-run medians over one-off numbers
+- for protocol work, validate both code and documentation parity
+- for model/science work, validate both correctness and outcome behavior
+
+Typical validation references:
+
+- `docs/TESTING.md`
+- `docs/PERF_RUNBOOK.md`
+- `docs/SCIENCE_BENCHMARKS.md`
+- `docs/STATISTICAL_REGRESSION.md`
+
+### 6. Document
+
+Documentation updates are part of the change, not follow-up chores.
+
+At minimum, update the relevant planning and behavior docs when they change:
+
+- `docs/PERFORMANCE_BACKLOG.md`
+- `docs/PERFORMANCE.md`
+- `docs/SIMULATION.md`
+- `docs/GENETICS.md`
+- `docs/PROTOCOL.md`
+- `docs/ARCHITECTURE.md`
+- `docs/PERF_RUNBOOK.md`
+- `docs/TESTING.md`
+- `docs/SCIENCE_BENCHMARKS.md`
+- `docs/STATISTICAL_REGRESSION.md`
+- `docs/SCALING_AND_BEHAVIOR_PLAN.md`
+- `docs/COLONY_INTELLIGENCE.md`
+- `docs/README.md`
+- `README.md`
+
+### 7. Open the PR
+
+- use the PR template in `.github/PULL_REQUEST_TEMPLATE.md`
+- link the issue with `Closes #...` or `Refs #...`
+- summarize the change, validation performed, and docs updated
+- note any follow-up issues intentionally left out of scope
+
+### 8. Review and Merge
+
+- request review and wait for required checks
+- address review feedback on the latest commit
+- re-run the necessary gates after significant follow-up changes
+- squash into logical commits if needed before merge
+
+### 9. Close the Loop
+
+After merge:
+
+- close or update the issue state
+- update the project item status
+- update umbrella issue checklists if scope is now complete or split further
+- create follow-up issues immediately if the merged work revealed new gaps
+
+## Definition of Done
+
+An issue is not done just because code landed. It is done when:
+
+- the scoped code change is merged
+- matching tests/benchmarks/validation landed or were updated
+- relevant documentation was updated in the same PR
+- linked issue/project state is current
+- any intentional follow-up work has its own issue
+
+## Development Rhythm
+
+The preferred rhythm for Ferox work is:
+
+1. research or observe a problem
+2. capture it in GitHub with evidence
+3. implement a narrow slice
+4. validate with the right test ladder
+5. update docs in the same PR
+6. merge and immediately re-triage follow-ons
+
+This keeps the codebase, the docs, and the GitHub project moving together.

--- a/docs/PERFORMANCE_BACKLOG.md
+++ b/docs/PERFORMANCE_BACKLOG.md
@@ -20,51 +20,51 @@ Priority values:
 - [x] `PERF-003` `P0` `done` Add queue telemetry (steal attempts/success, idle wakeups, queue depth percentiles).
 - [x] `PERF-004` `P0` `done` Add bounded MPMC fast path tuning knobs (capacity, spin thresholds, fallback mode).
 - [x] `PERF-005` `P1` `done` Implement batch stealing and victim randomization for better contention behavior.
-- [ ] `PERF-006` `P1` `open` Add strict fairness mode for starvation-sensitive workloads.
-- [ ] `PERF-007` `P1` `open` Add per-arena queues for latency-critical vs bulk background work.
-- [ ] `PERF-008` `P1` `open` Add NUMA-aware two-level stealing policy on Linux servers.
-- [ ] `PERF-009` `P2` `open` Add lock-free fallback queue backend feature flag for A/B evaluation.
+- [ ] `PERF-006` `P1` `open` Add strict fairness mode for starvation-sensitive workloads (`#111`).
+- [ ] `PERF-007` `P1` `open` Add per-arena queues for latency-critical vs bulk background work (`#112`).
+- [ ] `PERF-008` `P1` `open` Add NUMA-aware two-level stealing policy on Linux servers (`#113`).
+- [ ] `PERF-009` `P2` `open` Add lock-free fallback queue backend feature flag for A/B evaluation (`#114`).
 - [x] `PERF-010` `P2` `done` Add runtime scheduler profile presets (`latency`, `throughput`, `balanced`).
 
 ## Atomics, Memory Layout, and Data Access
 
-- [ ] `PERF-011` `P0` `open` Audit all atomic memory orders and document invariants per field.
-- [ ] `PERF-012` `P0` `open` Add alignment/padding checks for all hot shared structs (queue metadata, counters).
-- [ ] `PERF-013` `P0` `open` Replace global counters with sharded per-worker counters where possible.
-- [ ] `PERF-014` `P1` `open` Add cacheline-aware wrappers and static assertions in shared headers.
-- [ ] `PERF-015` `P1` `open` Add ARM/x86 specific microbench lane for atomic operation costs.
+- [ ] `PERF-011` `P0` `open` Audit all atomic memory orders and document invariants per field (`#115`).
+- [ ] `PERF-012` `P0` `open` Add alignment/padding checks for all hot shared structs (queue metadata, counters) (`#116`).
+- [ ] `PERF-013` `P0` `open` Replace global counters with sharded per-worker counters where possible (`#117`).
+- [ ] `PERF-014` `P1` `open` Add cacheline-aware wrappers and static assertions in shared headers (`#118`).
+- [ ] `PERF-015` `P1` `open` Add ARM/x86 specific microbench lane for atomic operation costs (`#119`).
 - [x] `PERF-016` `P1` `done` Add false-sharing diagnostics workflow (perf c2c + struct offset mapping).
-- [ ] `PERF-017` `P2` `open` Introduce thread-local submit fast path for worker-generated follow-on tasks.
-- [ ] `PERF-018` `P2` `open` Add optional RCU/QSBR for read-mostly metadata snapshots.
+- [ ] `PERF-017` `P2` `open` Introduce thread-local submit fast path for worker-generated follow-on tasks (`#120`).
+- [ ] `PERF-018` `P2` `open` Add optional RCU/QSBR for read-mostly metadata snapshots (`#121`).
 
 ## Simulation Core
 
-- [ ] `PERF-019` `P0` `open` Add sparse chunk/tile simulation mode for low occupancy maps.
-- [ ] `PERF-020` `P0` `open` Add dirty-tile tracking to avoid full-grid sync/scan every tick.
-- [ ] `PERF-021` `P0` `open` Add active frontier mode for spread/division candidate processing.
-- [ ] `PERF-022` `P1` `open` Add autotuned chunk sizes and scheduler chunk policy.
-- [ ] `PERF-023` `P1` `open` Add SIMD-ready SoA backend experiment for hot cell/colony fields.
-- [ ] `PERF-024` `P1` `open` Optimize division/recombination using tile-local CCL + border merge.
-- [ ] `PERF-025` `P1` `open` Add deterministic counter-based RNG mode (Philox-like) for parallel reproducibility.
-- [ ] `PERF-026` `P2` `open` Evaluate Morton/Hilbert ordering for chunk traversal and scheduling locality.
-- [ ] `PERF-027` `P2` `open` Add optional GPU-ready compute abstraction for future backend parity.
+- [ ] `PERF-019` `P0` `open` Add sparse chunk/tile simulation mode for low occupancy maps (`#122`).
+- [ ] `PERF-020` `P0` `open` Add dirty-tile tracking to avoid full-grid sync/scan every tick (`#97`).
+- [ ] `PERF-021` `P0` `open` Add active frontier mode for spread/division candidate processing (`#123`).
+- [ ] `PERF-022` `P1` `open` Add autotuned chunk sizes and scheduler chunk policy (`#124`).
+- [ ] `PERF-023` `P1` `open` Add SIMD-ready SoA backend experiment for hot cell/colony fields (`#125`).
+- [ ] `PERF-024` `P1` `open` Optimize division/recombination using tile-local CCL + border merge (`#108`).
+- [ ] `PERF-025` `P1` `open` Add deterministic counter-based RNG mode (Philox-like) for parallel reproducibility (`#100`).
+- [ ] `PERF-026` `P2` `open` Evaluate Morton/Hilbert ordering for chunk traversal and scheduling locality (`#126`).
+- [ ] `PERF-027` `P2` `open` Add optional GPU-ready compute abstraction for future backend parity (`#90`).
 
 ## Protocol and Networking
 
-- [ ] `PERF-028` `P0` `open` Add world-state delta messages to reduce full snapshot transport cost.
-- [ ] `PERF-029` `P0` `open` Add per-client baseline ring and robust ack-bitfield tracking.
-- [ ] `PERF-030` `P1` `open` Add adaptive codec selection (RLE-only vs delta+bitpack vs LZ4/Zstd path).
-- [ ] `PERF-031` `P1` `open` Add interest management prioritization to reduce irrelevant updates.
-- [ ] `PERF-032` `P1` `open` Add paced UDP send policy and packet batching metrics.
-- [ ] `PERF-033` `P1` `open` Add jitter-buffer and interpolation delay tuning metrics on client.
-- [ ] `PERF-034` `P2` `open` Add Merkle/chunk-hash anti-entropy path for resync/recovery scenarios.
+- [ ] `PERF-028` `P0` `open` Add world-state delta messages to reduce full snapshot transport cost (`#127`).
+- [ ] `PERF-029` `P0` `open` Add per-client baseline ring and robust ack-bitfield tracking (`#128`).
+- [ ] `PERF-030` `P1` `open` Add adaptive codec selection (RLE-only vs delta+bitpack vs LZ4/Zstd path) (`#129`).
+- [ ] `PERF-031` `P1` `open` Add interest management prioritization to reduce irrelevant updates (`#130`).
+- [ ] `PERF-032` `P1` `open` Add paced UDP send policy and packet batching metrics (`#131`).
+- [ ] `PERF-033` `P1` `open` Add jitter-buffer and interpolation delay tuning metrics on client (`#132`).
+- [ ] `PERF-034` `P2` `open` Add Merkle/chunk-hash anti-entropy path for resync/recovery scenarios (`#133`).
 
 ## Allocation and Memory Management
 
-- [ ] `PERF-035` `P0` `open` Add per-thread pools for hot task descriptors and cross-thread free handoff.
-- [ ] `PERF-036` `P1` `open` Add frame/phase arena for transient simulation allocations.
-- [ ] `PERF-037` `P1` `open` Add allocator benchmark matrix (system malloc vs tuned allocator backends).
-- [ ] `PERF-038` `P2` `open` Add generation-safe handle pool for recycled transient objects.
+- [ ] `PERF-035` `P0` `open` Add per-thread pools for hot task descriptors and cross-thread free handoff (`#134`).
+- [ ] `PERF-036` `P1` `open` Add frame/phase arena for transient simulation allocations (`#135`).
+- [ ] `PERF-037` `P1` `open` Add allocator benchmark matrix (system malloc vs tuned allocator backends) (`#136`).
+- [ ] `PERF-038` `P2` `open` Add generation-safe handle pool for recycled transient objects (`#137`).
 
 ## Testing, Benchmarking, and Operations
 
@@ -74,17 +74,25 @@ Priority values:
 - [x] `PERF-042` `P1` `done` Add profile scripts for perf/flamegraph and Apple Instruments capture.
 - [x] `PERF-043` `P1` `done` Add reproducible perf baseline files for x86_64 and Apple arm64.
 - [x] `PERF-044` `P1` `done` Add nightly benchmark artifact export (CSV/JSON) with diff summary.
-- [ ] `PERF-045` `P2` `open` Add perf-per-watt tracking mode for mobile/ARM hardware.
+- [ ] `PERF-045` `P2` `open` Add perf-per-watt tracking mode for mobile/ARM hardware (`#138`).
 
 ## Current Parallel Workstreams
 
 - [x] `PERF-046` `P0` `done` Improve threadpool tiny-task scaling and validate with microbench.
 - [x] `PERF-047` `P0` `done` Improve spread-phase throughput scaling and validate with profiler.
 - [x] `PERF-048` `P1` `done` Expand benchmark coverage matrix and enforce stable metrics output.
-- [ ] `PERF-049` `P0` `open` Implement ticketed wakeups to reduce tiny-task wake inefficiency and jitter.
-- [ ] `PERF-050` `P0` `open` Add frontier hysteresis (low/high density thresholds) to avoid spread mode thrash.
-- [ ] `PERF-051` `P1` `open` Prototype MPSC ingress ring + combiner drain for submit-side lock reduction.
-- [ ] `PERF-052` `P1` `open` Add sparse/dense frontier representation switching (index-list vs bitset).
+- [ ] `PERF-049` `P0` `open` Implement ticketed wakeups to reduce tiny-task wake inefficiency and jitter (`#139`).
+- [ ] `PERF-050` `P0` `open` Add frontier hysteresis (low/high density thresholds) to avoid spread mode thrash (`#140`).
+- [ ] `PERF-051` `P1` `open` Prototype MPSC ingress ring + combiner drain for submit-side lock reduction (`#141`).
+- [ ] `PERF-052` `P1` `open` Add sparse/dense frontier representation switching (index-list vs bitset) (`#142`).
 - [x] `PERF-053` `P1` `done` Add hardware profile detection plus CPU/Apple/AMD runtime target selection and reporting.
-- [ ] `PERF-054` `P0` `open` Rebaseline performance and transport costs for the new `400x200` / `50` colony default profile (`#89`, `#91`, `#88`).
-- [ ] `PERF-055` `P1` `open` Continue atomic ecology parity and richer behavior rollout (`#92`, `#87`).
+- [ ] `PERF-054` `P0` `open` Rebaseline performance and transport costs for the new `400x200` / `50` colony default profile (`#89`, `#91`, `#88`, `#143`).
+- [ ] `PERF-055` `P1` `open` Continue atomic ecology parity and richer behavior rollout (`#92`, `#87`, `#101`, `#102`, `#103`, `#104`, `#105`).
+
+## Additional Issue-Backed Follow-Ups
+
+- `#98` Make frontier telemetry incremental and scratch-buffer based.
+- `#99` Isolate slow clients with queued/coalesced world broadcasts.
+- `#106` Make `simulation_update_colony_dynamics()` allocation-free and avoid duplicate scans.
+- `#107` Remove redundant chunk build/copy work from the large-world broadcast path.
+- `#110` Reconcile the protocol spec with the live wire format and version future changes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -259,6 +259,17 @@ ferox/
 - [Scaling and Behavior Plan](SCALING_AND_BEHAVIOR_PLAN.md) - Current rollout plan and linked GitHub issues
 - [Progress](PROGRESS.md) - Current project status and active workstreams
 - [Contributing](CONTRIBUTING.md) - Development guidelines
+- [Development Cycle](DEVELOPMENT_CYCLE.md) - Issue intake, project tracking, validation, docs updates, and merge flow
+
+## GitHub Project Hygiene
+
+- Use the `Ferox Research Backlog` GitHub Project for the current research sweep.
+- Prefer the issue templates under `.github/ISSUE_TEMPLATE/` for new perf,
+  protocol, model, and science work so validation and documentation follow-up are
+  captured up front.
+- Keep linked planning docs updated in the same PR as implementation work.
+- Follow `DEVELOPMENT_CYCLE.md` for the standard capture -> triage -> implement ->
+  validate -> document -> review -> merge loop.
 
 ## License
 

--- a/docs/SCALING_AND_BEHAVIOR_PLAN.md
+++ b/docs/SCALING_AND_BEHAVIOR_PLAN.md
@@ -37,6 +37,15 @@ worlds, richer colony behavior, and the follow-on work now tracked in GitHub.
 - `#91` Remove per-colony full-grid rescans from world broadcast path
 - `#88` Scale world-state transport for larger maps and colony counts
 - `#90` Define a backend interface for future CPU/GPU simulation execution
+- `#97` Add dirty-tile AtomicWorld sync to avoid full-grid copies each tick
+- `#99` Isolate slow clients with queued/coalesced world broadcasts
+- `#100` Unify RNG sources and add exact replay fixtures
+- `#101` Wire Monod uptake and EPS-dependent transport into the live runtime
+- `#103` Split atomic serial maintenance cadence by freshness requirements
+- `#107` Remove redundant chunk build/copy work from the large-world broadcast path
+- `#109` Execute configured benchmark scenarios and enforce pass bands in CI
+- `#110` Reconcile the protocol spec with the live wire format and version future changes
+- `#143` Rebaseline performance and transport costs for the new default world profile
 
 ## Validation Focus
 
@@ -46,8 +55,9 @@ worlds, richer colony behavior, and the follow-on work now tracked in GitHub.
 
 ## Next Recommended Moves
 
-- rebaseline perf targets for the new `400x200` / `50` colony default profile
-- tighten snapshot-build and chunked-transport perf guardrails with target values
-- continue reducing GUI and terminal client render overhead on dense large worlds
-- keep the CPU atomic backend as reference while defining the future accelerator
+- rebaseline perf targets for the new `400x200` / `50` colony default profile (`#143`)
+- tighten snapshot-build and chunked-transport perf guardrails with target values (`#107`, `#127`, `#128`)
+- continue reducing GUI and terminal client render overhead on dense large worlds (`#99`)
+- keep the CPU atomic backend as reference while defining the future accelerator backend seam (`#90`)
+- land follow-up ecology/runtime work with docs updates in the same PRs (`#101`, `#103`, `#105`)
   backend seam

--- a/docs/SCIENCE_BENCHMARKS.md
+++ b/docs/SCIENCE_BENCHMARKS.md
@@ -75,3 +75,9 @@ The run plan emits scenario-specific `scripts/run.sh server ...` command lines a
 - Full local validation: `python3 scripts/science_benchmarks.py validate --strict`
 
 Both commands validate the scenario schema and canonical coverage; they fail fast on malformed fields, invalid pass bands, duplicate IDs, or missing required scenarios.
+
+## Active Tracking
+
+- `#109` Execute configured benchmark scenarios and enforce pass bands in CI.
+- `#138` Add perf-per-watt tracking mode for mobile/ARM hardware.
+- Keep `docs/SCIENCE_BENCHMARKS.md`, `docs/STATISTICAL_REGRESSION.md`, `docs/TESTING.md`, and `docs/PERF_RUNBOOK.md` updated as benchmark automation evolves.

--- a/docs/STATISTICAL_REGRESSION.md
+++ b/docs/STATISTICAL_REGRESSION.md
@@ -50,3 +50,9 @@ The test logs machine-parseable lines in this format:
 `STAT_REGRESSION metric=<name> mean=<v> stddev=<v> min=<v> max=<v> expected_mean=<v> mean_tol=<v> expected_stddev=<v> stddev_tol=<v>`
 
 This gives pass/fail and observability without relying on fragile golden output files.
+
+## Related Tracking
+
+- `#100` Unify RNG sources and add exact replay fixtures to complement the statistical lane with exact deterministic checks.
+- `#109` Execute configured benchmark scenarios and enforce pass bands in CI for broader science-facing validation.
+- Keep this document updated alongside `docs/SCIENCE_BENCHMARKS.md`, `docs/TESTING.md`, and any replay/test workflow changes.


### PR DESCRIPTION
## Summary
- document the Ferox development cycle from issue intake through merge follow-up
- add GitHub issue templates and a PR template so validation and documentation expectations are captured up front
- link the new workflow/process docs from contributor-facing documentation and planning docs

## Validation
- `ctest --test-dir build --output-on-failure -R \"ScienceBenchmarkConfigTests|SimulationStatRegressionTests|ProtocolEdgeTests\"`

## Documentation
- updates the process docs, backlog cross-links, and contributor guidance in the same PR

Refs #144
Refs #145
Refs #146
Refs #147
Refs #148