### PR TITLE
docs: record merged backlog follow-through

### DIFF
--- a/docs/PERFORMANCE_BACKLOG.md
+++ b/docs/PERFORMANCE_BACKLOG.md
@@ -29,10 +29,10 @@ Priority values:
 ## Atomics, Memory Layout, and Data Access
 
 - [ ] `PERF-011` `P0` `open` Audit all atomic memory orders and document invariants per field (`#115`).
-- [x] `PERF-012` `P0` `done` Add alignment/padding checks for all hot shared structs (queue metadata, counters) (`#116`).
+- [x] `PERF-012` `P0` `done` Add alignment/padding checks for all hot shared structs (queue metadata, counters) (`#116`, merged in `#152`).
 - [ ] `PERF-013` `P0` `open` Replace global counters with sharded per-worker counters where possible (`#117`).
 - [ ] `PERF-014` `P1` `open` Add cacheline-aware wrappers and static assertions in shared headers (`#118`).
-- [x] `PERF-015` `P1` `done` Add ARM/x86 specific microbench lane for atomic operation costs (`#119`).
+- [x] `PERF-015` `P1` `done` Add ARM/x86 specific microbench lane for atomic operation costs (`#119`, merged in `#151`).
 - [x] `PERF-016` `P1` `done` Add false-sharing diagnostics workflow (perf c2c + struct offset mapping).
 - [ ] `PERF-017` `P2` `open` Introduce thread-local submit fast path for worker-generated follow-on tasks (`#120`).
 - [ ] `PERF-018` `P2` `open` Add optional RCU/QSBR for read-mostly metadata snapshots (`#121`).

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -39,6 +39,10 @@ hardware-aware runtime tuning.
   - `docs/PERF_RUNBOOK.md`
   - `docs/PERF_TARGETS.md`
   - `docs/PERFORMANCE_BACKLOG.md`
+- Recent merged follow-through:
+  - `#151` architecture-specific atomic cost lane
+  - `#152` hot-struct cacheline alignment/padding guardrails
+  - `#153` protocol spec/conformance sync with the live wire format
 
 ## Active Workstreams
 
@@ -83,3 +87,4 @@ Current thresholds and next target values are maintained in
 - Close tracked rollout issues `#89`, `#92`, and `#87`
 - Rebaseline perf targets and history for the larger default workload
 - Remove transport and broadcast scaling blockers tracked in `#91` and `#88`
+- Advance the next open P0/P1 backlog issues after `#151`, `#152`, and `#153`

--- a/docs/SCALING_AND_BEHAVIOR_PLAN.md
+++ b/docs/SCALING_AND_BEHAVIOR_PLAN.md
@@ -44,7 +44,7 @@ worlds, richer colony behavior, and the follow-on work now tracked in GitHub.
 - `#103` Split atomic serial maintenance cadence by freshness requirements
 - `#107` Remove redundant chunk build/copy work from the large-world broadcast path
 - `#109` Execute configured benchmark scenarios and enforce pass bands in CI
-- `#110` Reconcile the protocol spec with the live wire format and version future changes
+- `#110` Reconcile the protocol spec with the live wire format and version future changes (`#153`)
 - `#143` Rebaseline performance and transport costs for the new default world profile
 
 ## Validation Focus


### PR DESCRIPTION
## Summary
- update planning/progress docs to reflect the merges for #151, #152, and #153
- tighten backlog references so the merged protocol and perf follow-through is visible in repo docs
- keep documentation state current before moving on to the next implementation batch

## Validation
- documentation-only follow-through