### PR TITLE
perf: add worker follow-on submit fast path (#120)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -70,10 +70,19 @@ The threadpool evolved from a simple global FIFO to a mixed scheduler:
 - per-worker queues (`WorkerQueue`) for locality and reduced global contention
 - lock-free fast queues (`FastTaskQueue`) for hot paths
 - owner-local submit and batching controls
+- worker-generated follow-on submit fast path that reuses thread-local worker identity to push directly into the submitting worker's local queue before falling back to shared ingress paths
 - work stealing controls (`steal_probe_limit`, `steal_batch_size`)
 - profile presets via `FEROX_THREADPOOL_PROFILE`
 - optional telemetry in `ThreadPoolTelemetry`
 - cacheline-padded `ThreadPoolHotCounters` so queue-depth / active-task updates do not share a line with colder pool pointers and synchronization objects
+
+The fast path is intentionally narrow-scope: it only targets single-task submits
+issued by an active pool worker while that worker is already executing Ferox
+threadpool work. Those follow-on tasks stay thread-local until the current task
+finishes, which avoids an extra shared-queue enqueue/dequeue round-trip for the
+worker-chained case. External producers, non-worker threads, and batch submit
+calls continue to use the existing shared submit path so semantics, wakeups, and
+fallback behavior stay unchanged.
 
 Relevant files:
 

--- a/docs/PERFORMANCE_BACKLOG.md
+++ b/docs/PERFORMANCE_BACKLOG.md
@@ -34,7 +34,7 @@ Priority values:
 - [ ] `PERF-014` `P1` `open` Add cacheline-aware wrappers and static assertions in shared headers (`#118`).
 - [x] `PERF-015` `P1` `done` Add ARM/x86 specific microbench lane for atomic operation costs (`#119`, merged in `#151`).
 - [x] `PERF-016` `P1` `done` Add false-sharing diagnostics workflow (perf c2c + struct offset mapping).
-- [ ] `PERF-017` `P2` `open` Introduce thread-local submit fast path for worker-generated follow-on tasks (`#120`).
+- [x] `PERF-017` `P2` `done` Introduce thread-local submit fast path for worker-generated follow-on tasks (`#120`).
 - [ ] `PERF-018` `P2` `open` Add optional RCU/QSBR for read-mostly metadata snapshots (`#121`).
 
 ## Simulation Core

--- a/docs/PERF_RUNBOOK.md
+++ b/docs/PERF_RUNBOOK.md
@@ -30,6 +30,22 @@ without chasing noisy one-off results.
 - Jitter-reduced summary (multi-iteration):
   - `./scripts/perf_multi_iter.py -n 7 --profile balanced`
 
+## Issue #120 Validation Notes
+
+- The worker-submit fast path is only expected to help worker-generated follow-on
+  tasks (nested/chained submits from inside threadpool jobs).
+- Benchmark the change primarily with `test_performance_eval` and compare the
+  `threadpool worker follow-on` lane plus the existing tiny-task metrics against
+  the pre-change baseline on the same host.
+- Keep `test_threadpool_profile_scan` and `test_threadpool_stress` in the
+  validation set to catch regressions in wakeups, stealing, or queue accounting.
+- The current implementation is deliberately limited to worker-issued
+  `threadpool_submit()` follow-on tasks; `threadpool_submit_batch()` still uses
+  the shared queue path and should remain neutral in comparisons.
+- If results regress for external producer workloads but improve for chained
+  worker workloads, treat that as a rollback signal because this change is meant
+  to be low-risk and workload-specific rather than a global scheduler rewrite.
+
 ## Granularity Ladder
 
 - `unit`:

--- a/src/server/threadpool.c
+++ b/src/server/threadpool.c
@@ -9,6 +9,82 @@
 
 #define TASK_FREELIST_LIMIT 4096
 
+typedef struct WorkerLocalState {
+    ThreadPool* pool;
+    Task* submit_head;
+    Task* submit_tail;
+    Task* free_list;
+    int free_count;
+} WorkerLocalState;
+
+static pthread_key_t worker_state_key;
+static pthread_once_t worker_state_key_once = PTHREAD_ONCE_INIT;
+
+static void threadpool_make_worker_state_key(void) {
+    (void)pthread_key_create(&worker_state_key, NULL);
+}
+
+static WorkerLocalState* threadpool_current_worker_state(void) {
+    pthread_once(&worker_state_key_once, threadpool_make_worker_state_key);
+    return (WorkerLocalState*)pthread_getspecific(worker_state_key);
+}
+
+static void threadpool_set_worker_state(WorkerLocalState* state) {
+    pthread_once(&worker_state_key_once, threadpool_make_worker_state_key);
+    (void)pthread_setspecific(worker_state_key, state);
+}
+
+static Task* threadpool_take_free_task_local(WorkerLocalState* state) {
+    if (state == NULL || state->free_list == NULL) {
+        return NULL;
+    }
+
+    Task* task = state->free_list;
+    state->free_list = task->next;
+    task->next = NULL;
+    state->free_count--;
+    return task;
+}
+
+static void threadpool_recycle_task_local(WorkerLocalState* state, Task* task) {
+    if (state == NULL || task == NULL) {
+        return;
+    }
+
+    if (state->free_count < TASK_FREELIST_LIMIT) {
+        task->next = state->free_list;
+        state->free_list = task;
+        state->free_count++;
+        return;
+    }
+
+    free(task);
+}
+
+static void threadpool_enqueue_local_task(WorkerLocalState* state, Task* task) {
+    if (state->submit_tail == NULL) {
+        state->submit_head = task;
+        state->submit_tail = task;
+    } else {
+        state->submit_tail->next = task;
+        state->submit_tail = task;
+    }
+}
+
+static Task* threadpool_pop_local_task(WorkerLocalState* state) {
+    if (state == NULL || state->submit_head == NULL) {
+        return NULL;
+    }
+
+    Task* task = state->submit_head;
+    state->submit_head = task->next;
+    if (state->submit_head == NULL) {
+        state->submit_tail = NULL;
+    }
+    task->next = NULL;
+    return task;
+}
+
 static Task* threadpool_take_free_task_locked(ThreadPool* pool) {
     Task* task = pool->task_free_list;
     if (task != NULL) {
@@ -19,21 +95,6 @@ static Task* threadpool_take_free_task_locked(ThreadPool* pool) {
     return task;
 }
 
-static void threadpool_recycle_task_locked(ThreadPool* pool, Task* task) {
-    if (task == NULL) {
-        return;
-    }
-
-    if (pool->counters.task_free_count < TASK_FREELIST_LIMIT) {
-        task->next = pool->task_free_list;
-        pool->task_free_list = task;
-        pool->counters.task_free_count++;
-        return;
-    }
-
-    free(task);
-}
-
 static void threadpool_free_task_list(Task* head) {
     while (head != NULL) {
         Task* next = head->next;
@@ -42,9 +103,35 @@ static void threadpool_free_task_list(Task* head) {
     }
 }
 
+static void threadpool_execute_local_tasks(ThreadPool* pool, WorkerLocalState* state) {
+    while (1) {
+        pthread_mutex_lock(&pool->queue_mutex);
+        Task* task = threadpool_pop_local_task(state);
+        if (task != NULL) {
+            pool->counters.pending_tasks--;
+        }
+        pthread_mutex_unlock(&pool->queue_mutex);
+
+        if (task == NULL) {
+            return;
+        }
+
+        task->function(task->arg);
+        threadpool_recycle_task_local(state, task);
+    }
+}
+
 // Worker thread function
 static void* worker_thread(void* arg) {
     ThreadPool* pool = (ThreadPool*)arg;
+    WorkerLocalState local_state = {
+        .pool = pool,
+        .submit_head = NULL,
+        .submit_tail = NULL,
+        .free_list = NULL,
+        .free_count = 0,
+    };
+    threadpool_set_worker_state(&local_state);
     
     while (1) {
         pthread_mutex_lock(&pool->queue_mutex);
@@ -76,10 +163,15 @@ static void* worker_thread(void* arg) {
         // Execute the task outside the lock
         if (task != NULL) {
             task->function(task->arg);
+            threadpool_execute_local_tasks(pool, &local_state);
 
             pthread_mutex_lock(&pool->queue_mutex);
             pool->counters.active_tasks--;
-            threadpool_recycle_task_locked(pool, task);
+            pthread_mutex_unlock(&pool->queue_mutex);
+
+            threadpool_recycle_task_local(&local_state, task);
+
+            pthread_mutex_lock(&pool->queue_mutex);
             
             // Signal if all tasks are done
             if (pool->counters.active_tasks == 0 && pool->counters.pending_tasks == 0) {
@@ -88,6 +180,10 @@ static void* worker_thread(void* arg) {
             pthread_mutex_unlock(&pool->queue_mutex);
         }
     }
+
+    threadpool_set_worker_state(NULL);
+    threadpool_free_task_list(local_state.submit_head);
+    threadpool_free_task_list(local_state.free_list);
     
     return NULL;
 }
@@ -208,6 +304,34 @@ void threadpool_submit(ThreadPool* pool, task_func func, void* arg) {
     if (pool == NULL || func == NULL) {
         return;
     }
+
+    WorkerLocalState* worker_state = threadpool_current_worker_state();
+    if (worker_state != NULL && worker_state->pool == pool) {
+        Task* task = threadpool_take_free_task_local(worker_state);
+        if (task == NULL) {
+            task = (Task*)malloc(sizeof(Task));
+            if (task == NULL) {
+                return;
+            }
+        }
+
+        task->function = func;
+        task->arg = arg;
+        task->next = NULL;
+
+        pthread_mutex_lock(&pool->queue_mutex);
+        if (pool->counters.shutdown) {
+            pthread_mutex_unlock(&pool->queue_mutex);
+            threadpool_recycle_task_local(worker_state, task);
+            return;
+        }
+        pool->counters.pending_tasks++;
+        pthread_mutex_unlock(&pool->queue_mutex);
+
+        threadpool_enqueue_local_task(worker_state, task);
+        return;
+    }
+
     pthread_mutex_lock(&pool->queue_mutex);
 
     // Don't accept new tasks if shutting down

--- a/tests/test_performance_eval.c
+++ b/tests/test_performance_eval.c
@@ -90,10 +90,24 @@ typedef struct {
     int iterations;
 } PerfTaskBatch;
 
+typedef struct {
+    ThreadPool* pool;
+    atomic_int remaining;
+} PerfFollowOnChainState;
+
 static void perf_increment_task_batch(void* arg) {
     PerfTaskBatch* batch = (PerfTaskBatch*)arg;
     for (int i = 0; i < batch->iterations; i++) {
         atomic_fetch_add(&perf_task_counter, 1);
+    }
+}
+
+static void perf_follow_on_increment_task(void* arg) {
+    PerfFollowOnChainState* state = (PerfFollowOnChainState*)arg;
+    atomic_fetch_add(&perf_task_counter, 1);
+
+    if (atomic_fetch_sub(&state->remaining, 1) > 0) {
+        threadpool_submit(state->pool, perf_follow_on_increment_task, state);
     }
 }
 
@@ -733,6 +747,30 @@ TEST(threadpool_granularity_eval) {
     threadpool_destroy(pool);
 }
 
+TEST(threadpool_worker_follow_on_submit_eval) {
+    const int scale = get_perf_scale();
+    const int total_increments = 50000 * scale;
+
+    ThreadPool* pool = threadpool_create(4);
+    ASSERT_NOT_NULL(pool);
+
+    atomic_store(&perf_task_counter, 0);
+    PerfFollowOnChainState state = {
+        .pool = pool,
+        .remaining = ATOMIC_VAR_INIT(total_increments - 1),
+    };
+
+    double start = now_ms();
+    threadpool_submit(pool, perf_follow_on_increment_task, &state);
+    threadpool_wait(pool);
+    double elapsed = now_ms() - start;
+
+    ASSERT_EQ(atomic_load(&perf_task_counter), total_increments);
+    print_metric("threadpool worker follow-on", elapsed, (double)total_increments);
+
+    threadpool_destroy(pool);
+}
+
 int run_performance_eval_tests(void) {
     tests_passed = 0;
     tests_failed = 0;
@@ -753,6 +791,7 @@ int run_performance_eval_tests(void) {
     RUN_TEST(atomic_sync_throughput_scaling_eval);
     RUN_TEST(threadpool_task_throughput);
     RUN_TEST(threadpool_granularity_eval);
+    RUN_TEST(threadpool_worker_follow_on_submit_eval);
 
     printf("\n--- Performance Eval Results ---\n");
     printf("Passed: %d\n", tests_passed);

--- a/tests/test_phase3.c
+++ b/tests/test_phase3.c
@@ -10,6 +10,7 @@
 #include <unistd.h>
 #include <pthread.h>
 #include <assert.h>
+#include <stdatomic.h>
 #include "../src/server/threadpool.h"
 #include "../src/server/parallel.h"
 
@@ -60,6 +61,21 @@ static void record_thread_id(void* arg) {
     int idx = (*targ->index)++;
     targ->thread_ids[idx] = pthread_self();
     pthread_mutex_unlock(targ->mutex);
+}
+
+typedef struct {
+    ThreadPool* pool;
+    atomic_int remaining;
+    atomic_int executed;
+} FollowOnChainState;
+
+static void submit_follow_on_task(void* arg) {
+    FollowOnChainState* state = (FollowOnChainState*)arg;
+    atomic_fetch_add(&state->executed, 1);
+
+    if (atomic_fetch_sub(&state->remaining, 1) > 0) {
+        threadpool_submit(state->pool, submit_follow_on_task, state);
+    }
 }
 
 // ============================================================================
@@ -294,6 +310,30 @@ static int test_threadpool_submit_batch_executes_all_tasks(void) {
     threadpool_wait(pool);
 
     ASSERT_EQ(counter, 50);
+
+    threadpool_destroy(pool);
+    TEST_PASS();
+    return 0;
+}
+
+static int test_threadpool_worker_follow_on_submit_completes_chain(void) {
+    TEST_START("threadpool worker follow-on submit chain");
+
+    ThreadPool* pool = threadpool_create(4);
+    ASSERT_NOT_NULL(pool);
+
+    FollowOnChainState state = {
+        .pool = pool,
+        .remaining = ATOMIC_VAR_INIT(255),
+        .executed = ATOMIC_VAR_INIT(0),
+    };
+
+    threadpool_submit(pool, submit_follow_on_task, &state);
+    threadpool_wait(pool);
+
+    ASSERT_EQ(atomic_load(&state.executed), 256);
+    ASSERT_EQ(pool->counters.pending_tasks, 0);
+    ASSERT_EQ(pool->counters.active_tasks, 0);
 
     threadpool_destroy(pool);
     TEST_PASS();
@@ -583,6 +623,7 @@ int main(void) {
     failed += test_threadpool_destroy_completes_pending_tasks();
     failed += test_threadpool_handles_1000_tasks();
     failed += test_threadpool_submit_batch_executes_all_tasks();
+    failed += test_threadpool_worker_follow_on_submit_completes_chain();
     
     printf("\n[Parallel Context Tests]\n");
     failed += test_parallel_context_creates_four_regions();

--- a/tests/test_threadpool_stress.c
+++ b/tests/test_threadpool_stress.c
@@ -75,6 +75,20 @@ static void variable_time_task(void* arg) {
     atomic_fetch_add(&task_counter, 1);
 }
 
+typedef struct {
+    ThreadPool* pool;
+    atomic_int remaining;
+} FollowOnStressState;
+
+static void follow_on_stress_task(void* arg) {
+    FollowOnStressState* state = (FollowOnStressState*)arg;
+    atomic_fetch_add(&task_counter, 1);
+
+    if (atomic_fetch_sub(&state->remaining, 1) > 0) {
+        threadpool_submit(state->pool, follow_on_stress_task, state);
+    }
+}
+
 // ============================================================================
 // Basic Stress Tests
 // ============================================================================
@@ -243,6 +257,27 @@ TEST(batch_submit_with_remainder) {
 
     threadpool_wait(pool);
     ASSERT_EQ(atomic_load(&task_counter), total);
+
+    threadpool_destroy(pool);
+}
+
+TEST(worker_follow_on_submit_chain) {
+    ThreadPool* pool = threadpool_create(4);
+    ASSERT_NOT_NULL(pool);
+
+    atomic_store(&task_counter, 0);
+
+    FollowOnStressState state = {
+        .pool = pool,
+        .remaining = ATOMIC_VAR_INIT(999),
+    };
+
+    threadpool_submit(pool, follow_on_stress_task, &state);
+    threadpool_wait(pool);
+
+    ASSERT_EQ(atomic_load(&task_counter), 1000);
+    ASSERT_EQ(pool->counters.pending_tasks, 0);
+    ASSERT_EQ(pool->counters.active_tasks, 0);
 
     threadpool_destroy(pool);
 }
@@ -505,6 +540,7 @@ int run_threadpool_stress_tests(void) {
     RUN_TEST(rapid_submit_wait_cycles);
     RUN_TEST(interleaved_submit_wait);
     RUN_TEST(batch_submit_with_remainder);
+    RUN_TEST(worker_follow_on_submit_chain);
     RUN_TEST(hot_shared_structs_are_cacheline_aligned);
     
     printf("\nConcurrent Submit Tests:\n");


### PR DESCRIPTION
## Summary
- document the scope and validation guidance for the worker-generated submit fast path before code changes
- add a narrow thread-local fast path for worker-issued follow-on `threadpool_submit()` calls while keeping external and batch submit behavior unchanged
- extend correctness and perf coverage with chained follow-on submit tests and a worker-follow-on benchmark lane

## Testing
- `cmake -S . -B build`
- `cmake --build build --target test_phase3 test_threadpool_stress test_performance_eval`
- `ctest --test-dir build --output-on-failure -R "Phase3Tests|ThreadpoolStressTests|PerformanceEvalTests"`

Closes #120.